### PR TITLE
Fixed link for google CSP bypass

### DIFF
--- a/XSS Injection/README.md
+++ b/XSS Injection/README.md
@@ -779,7 +779,7 @@ Exotic payloads
 
 ## CSP Bypass
 
-Check the CSP on [https://csp-evaluator.withgoogle.com](https://csp-evaluator.withgoogle.com) and the post : [How to use Google’s CSP Evaluator to bypass CSP](https://blog.thomasorlita.cz/vulns/google-csp-evaluator/)
+Check the CSP on [https://csp-evaluator.withgoogle.com](https://csp-evaluator.withgoogle.com) and the post : [How to use Google’s CSP Evaluator to bypass CSP](https://appio.dev/vulns/google-csp-evaluator/)
 
 ### Bypass CSP using JSONP from Google (Trick by [@apfeifer27](https://twitter.com/apfeifer27))
 


### PR DESCRIPTION
Found a dead link, it redirects to appio.dev which led me to the new location of the article: https://appio.dev/vulns/google-csp-evaluator/