### PR TITLE
Remove "Leaked API keys" section

### DIFF
--- a/Insecure Source Code Management/README.md
+++ b/Insecure Source Code Management/README.md
@@ -16,7 +16,6 @@
 - [BAZAAR - Source code management](#bazaar---source-code-management)
   - [Automatic way : rip-bzr](#automatic-way--rip-bzr)
   - [Automatic way : bzr_dumper](#automatic-way--bzr_dumper)
-- [Leaked API keys](#leaked-api-keys)
 
 ## GIT - Source code management
 
@@ -236,16 +235,6 @@ $ bzr revert
  N  application.py
  N  database.py
  N  static/   
-```
-
-## Leaked API keys
-
-If you find any key , use the [keyhacks](https://github.com/streaak/keyhacks) from @streaak to verifiy them.
-
-Twilio example :
-
-```powershell
-curl -X GET 'https://api.twilio.com/2010-04-01/Accounts/ACCOUNT_SID/Keys.json' -u ACCOUNT_SID:AUTH_TOKEN
 ```
 
 ## References


### PR DESCRIPTION
It's in the "API Key Leaks" folder now and the content is already present there