### PR TITLE
Added cURL command for Wayback Machine querying

### DIFF
--- a/Methodology and Resources/Methodology and enumeration.md
+++ b/Methodology and Resources/Methodology and enumeration.md
@@ -38,6 +38,7 @@
 
   ```bash
   look for JS files, old links
+  curl -sX GET "http://web.archive.org/cdx/search/cdx?url=<targetDomain.com>&output=text&fl=original&collapse=urlkey&matchType=prefix"
   ```
 
 * Using The Harvester (https://github.com/laramies/theHarvester)


### PR DESCRIPTION
Querying the Wayback Machine from the CLI is pretty helpful during recon.