### PR TITLE
Removed broken link

### DIFF
--- a/Methodology and Resources/Network Pivoting Techniques.md
+++ b/Methodology and Resources/Network Pivoting Techniques.md
@@ -348,7 +348,6 @@ unzip ngrok-stable-linux-amd64.zip
 
 ## References
 
-* [Network Pivoting Techniques - Bit rot](https://bitrot.sh/cheatsheet/14-12-2017-pivoting/)
 * [Port Forwarding in Windows - Windows OS Hub](http://woshub.com/port-forwarding-in-windows/)
 * [Using the SSH "Konami Code" (SSH Control Sequences) - Jeff McJunkin](https://pen-testing.sans.org/blog/2015/11/10/protected-using-the-ssh-konami-code-ssh-control-sequences)
 * [A Red Teamer's guide to pivoting- Mar 23, 2017 - Artem Kondratenko](https://artkond.com/2017/03/23/pivoting-guide/)


### PR DESCRIPTION
bitrot.sh domain is expired and hence the link in the markdown file was broken.