### PR TITLE
docs: fix simple typo, accound -> account

### DIFF
--- a/Methodology and Resources/Active Directory Attack.md
+++ b/Methodology and Resources/Active Directory Attack.md
@@ -1082,7 +1082,7 @@ Mitigations:
 
 ### Pass-the-Ticket Silver Tickets
 
-Forging a TGS require machine accound password (key) or NTLM hash of the service account.
+Forging a TGS require machine account password (key) or NTLM hash of the service account.
 
 ```powershell
 # Create a ticket for the service


### PR DESCRIPTION
There is a small typo in Methodology and Resources/Active Directory Attack.md.

Should read `account` rather than `accound`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md