### PR TITLE
GROUP_CONCAT equivelent for MSSQL

### DIFF
--- a/SQL Injection/MSSQL Injection.md
+++ b/SQL Injection/MSSQL Injection.md
@@ -64,6 +64,7 @@ SELECT DB_NAME()
 ```sql
 SELECT name FROM master..sysdatabases;
 SELECT DB_NAME(N); — for N = 0, 1, 2, …
+SELECT STRING_AGG(name, ', ') FROM master..sysdatabases; -- Change delimeter value such as ', ' to anything else you want => master, tempdb, model, msdb   (Only works in MSSQL 2017+)
 ```
 
 ## MSSQL List columns
@@ -83,6 +84,7 @@ SELECT name FROM someotherdb..sysobjects WHERE xtype = ‘U’;
 SELECT master..syscolumns.name, TYPE_NAME(master..syscolumns.xtype) FROM master..syscolumns, master..sysobjects WHERE master..syscolumns.id=master..sysobjects.id AND master..sysobjects.name=’sometable’; — list colum names and types for master..sometable
 
 SELECT table_catalog, table_name FROM information_schema.columns
+SELECT STRING_AGG(name, ', ') FROM master..sysobjects WHERE xtype = 'U'; -- Change delimeter value such as ', ' to anything else you want => trace_xe_action_map, trace_xe_event_map, spt_fallback_db, spt_fallback_dev, spt_fallback_usg, spt_monitor, MSreplication_options  (Only works in MSSQL 2017+)
 ```
 
 ## MSSQL Extract user/password


### PR DESCRIPTION
## Introduction
MSSQL 2017+ has an useful function called `STRING_AGG()` which I'd say is the most equivalent to `GROUP_CONCAT()` in another well known DMBS such as MySQL I find this approach makes the output not only cleaner, but also avoids you having to use other methods such as `ORDER BY name OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY` or anything along the lines of that where you have to specify `offset` or `limit` equivalent to MSSQL which is a lot more convoluted than it needs to be.

## Usage

For this instance, I'm running a mssql docker container for ease of use and I do not have a windows installation ready, but this should and will work on MSSQL.

### List all database names with a ', ' delimiter.


```sh
root@28153f762ac3:/# /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P toor123! -q "SELECT STRING_AGG(name, ', ') FROM master..sysdatabases;"
master, tempdb, model, msdb
(1 rows affected)
```

### List all tables names with a ', ' delimiter.

```sh
root@28153f762ac3:/# /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P toor123! -q "SELECT STRING_AGG(name, ', ') FROM master..sysobjects WHERE xtype = 'U';"
trace_xe_action_map, trace_xe_event_map, spt_fallback_db, spt_fallback_dev, spt_fallback_usg, spt_monitor, MSreplication_options
(1 rows affected)
````

I hope I've demonstrated to you well enough why or how this would be used, feel free to close this pull request if you deem it unnecessary or bad, thank you nonetheless, and have a good day. 

## More resources

If you need more understanding of the usage of this function, please read these materials which I've listed
https://docs.microsoft.com/en-us/sql/t-sql/functions/string-agg-transact-sql?view=sql-server-ver15
https://stackoverflow.com/questions/194852/how-to-concatenate-text-from-multiple-rows-into-a-single-text-string-in-sql-serv