### PR TITLE
Api Key Leaks: Add Trivy to tools section

### DIFF
--- a/API Key Leaks/README.md
+++ b/API Key Leaks/README.md
@@ -24,15 +24,16 @@
 ## Tools
 
 - [KeyFinder - is a tool that let you find keys while surfing the web!](https://github.com/momenbasel/KeyFinder)
-- [Keyhacks - is a repository which shows quick ways in which API keys leaked by a bug bounty program can be checked to see if they're valid.](https://github.com/streaak/keyhacks)
-- [truffleHog - Find credentials all over the place](https://github.com/trufflesecurity/truffleHog)
+- [KeyHacks - is a repository which shows quick ways in which API keys leaked by a bug bounty program can be checked to see if they're valid.](https://github.com/streaak/keyhacks)
+- [TruffleHog - Find credentials all over the place](https://github.com/trufflesecurity/truffleHog)
     ```ps1
     docker run -it -v "$PWD:/pwd" trufflesecurity/trufflehog:latest github --repo https://github.com/trufflesecurity/test_keys
     docker run -it -v "$PWD:/pwd" trufflesecurity/trufflehog:latest github --org=trufflesecurity
     trufflehog git https://github.com/trufflesecurity/trufflehog.git
     trufflehog github --endpoint https://api.github.com --org trufflesecurity --token GITHUB_TOKEN --debug --concurrency 2
     ```
-
+- [Trivy - General purpose vulnerability and misconfiguration scanner which also searches for API keys/secrets](https://github.com/aquasecurity/trivy)
+    
 ## Exploit
 
 The following commands can be used to takeover accounts or extract personal information from the API using the leaked token.


### PR DESCRIPTION
This will add [Trivy](https://github.com/aquasecurity/trivy) to the tools section of the topic `Api Key Leaks`. This is currently my go-to tool to scan docker images or repositories for secrets and therefore should be mentioned. As I could not see it mentioned somewhere, I picked this topic as it seemed to fit best. But it might also fit for other topics such as scanning for vulnerable dependencies (CVE) used in a projects or weaknesses in regards of SBOM/IaC. If you see a better fit for Trivy at other topics or might want to add it redundantly multiple times I guess we could add it to this MR.
Let me know what you think. :)

(Also changed the phrasing for two other tools as their main repository uses the upper/lowecase as changed which should not require a separate MR)