### PR TITLE
CVE Exploit: Add trickest CVE repo

### DIFF
--- a/CVE Exploits/README.md
+++ b/CVE Exploits/README.md
@@ -1,5 +1,9 @@
 # Common Vulnerabilities and Exposures
 
+## Tools
+
+- [Trickest CVE Repository - Automated collection of CVEs and PoC's](https://github.com/trickest/cve)
+
 ## Big CVEs in the last 5 years.
 
 ### CVE-2017-0144 - EternalBlue


### PR DESCRIPTION
This will add the trickiest CVE repository to the CVE Exploits section. Since the section of this topic kinda differs to the other topics I did not additionally add a Summary, if you would like to have it let me know and I can sort it out.
Nevertheless, I think that the trickest CVE repository is a really nice addition to quickly asses known CVE's for known PoC's since the list will be updated on a regular basis automatically.