### PR TITLE
Add Linux evasion to its own article

### DIFF
--- a/Methodology and Resources/Linux - Evasion.md
+++ b/Methodology and Resources/Linux - Evasion.md
@@ -1,0 +1,82 @@
+# Linux - Evasion
+
+## Summary
+
+- [File names](#file-names)
+- [Command history](#command-history)
+- [Hiding text](#hiding-text)
+
+
+## File Names
+
+An Unicode zero-width space can be inserted into filenames which makes the names visually indistinguishable:
+
+```bash
+# A decoy file with no special characters
+touch 'index.php'
+
+# An imposter file with visually identical name
+touch $'index\u200D.php'
+```
+
+
+## Command History
+
+Most shells save their command history so a user can recall them again later.  The command history can be viewed with the `history` command or by manually inspecting the contents of the file pointed to by `$HISTFILE` (e.g. `~/.bash_history`).
+This can be prevented in a number of ways.
+
+```bash
+# Prevent writing to the history file at all
+unset HISTFILE
+
+# Don't save this session's command history in memory
+export HISTSIZE=0
+```
+
+Individual commands that match a pattern in `HISTIGNORE` will be excluded from the command history, regardless of `HISTFILE` or `HISTSIZE` settings.  
+By default, `HISTIGNORE` will ignore all commands that begin with whitespace:
+
+```bash
+# Note the leading space character:
+ my-sneaky-command
+```
+
+If commands are accidentally added to the command history, individual command entries can be removed with `history -d`:
+
+```bash
+# Removes the most recently logged command.
+# Note that we actually have to delete two history entries at once,
+# otherwise the `history -d` command itself will be logged as well.
+history -d -2 && history -d -1
+```
+
+The entire command history can be purged as well, although this approach is much less subtle and very likely to be noticed:
+
+```bash
+# Clears the in-memory history and writes the empty history to disk.
+history -c && history -w
+```
+
+
+## Hiding Text
+
+ANSI escape sequences can be abused to hide text under certain circumstances.  
+If the file's contents are printed to the terminal (e.g. `cat`, `head`, `tail`) then the text will be hidden.  
+If the file is viewed with an editor (e.g. `vim`, `nano`, `emacs`), then the escape sequences will be visible.
+
+```bash
+echo "sneaky-payload-command" > script.sh
+echo "# $(clear)" >> script.sh
+echo "# Do not remove. Generated from /etc/issue.conf by configure." >> script.sh
+
+# When printed, the terminal will be cleared and only the last line will be visible:
+cat script.sh
+```
+
+
+## References
+
+- [ATT&CK - Impair Defenses: Impair Command History Logging](https://attack.mitre.org/techniques/T1562/003/)
+- [ATT&CK - Indicator Removal on Host: Clear Command History](https://attack.mitre.org/techniques/T1070/003/)
+- [ATT&CK - Masquerading: Match Legitimate Name or Location](https://attack.mitre.org/techniques/T1036/005/)
+- [Wikipedia - ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code)

--- a/Methodology and Resources/Linux - Persistence.md
+++ b/Methodology and Resources/Linux - Persistence.md
@@ -134,53 +134,6 @@ Add an ssh key into the `~/.ssh` folder.
 2. write the content of `~/.ssh/id_rsa.pub` into `~/.ssh/authorized_keys`
 3. set the right permission, 700 for ~/.ssh and 600 for authorized_keys
 
-## Tips
-
-Hide the payload with ANSI chars, the following chars will clear the terminal when using cat to display the content of your payload.
-
-```powershell
-#[2J[2J[2J[2H[2A# Do not remove. Generated from /etc/issue.conf by configure.
-```
-
-Hide in plain sight using zero width spaces in filename.
-
-```powershell
-touch $(echo -n 'index\u200D.php') index.php
-```
-
-Clear the last line of the history.
-
-```bash
-history -d $(history | tail -2 | awk '{print $1}') 2> /dev/null
-```
-
-Clear history
-
-```bash
-[SPACE] ANY COMMAND
-or
-export HISTSIZE=0
-export HISTFILESIZE=0
-unset HISTFILE; CTRL-D
-or
-kill -9 $$
-or
-echo "" > ~/.bash_history
-or
-rm ~/.bash_history -rf
-or
-history -c
-or
-ln /dev/null ~/.bash_history -sf
-```
-
-The following directories are temporary and usually writeable
-
-```bash
-/var/tmp/
-/tmp/
-/dev/shm/
-```
 ## Additional Persistence Options
 
 * [SSH Authorized Keys](https://attack.mitre.org/techniques/T1098/004)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You might also like the `Methodology and Resources` folder :
   - [Cloud - AWS Pentest.md](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Cloud%20-%20AWS%20Pentest.md)
   - [Cloud - Azure Pentest.md](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Cloud%20-%20Azure%20Pentest.md)
   - [Cobalt Strike - Cheatsheet.md](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Cobalt%20Strike%20-%20Cheatsheet.md)
+  - [Linux - Evasion.md](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Linux%20-%20Evasion.md)
   - [Linux - Persistence.md](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Linux%20-%20Persistence.md)
   - [Linux - Privilege Escalation.md](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Linux%20-%20Privilege%20Escalation.md)
   - [Metasploit - Cheatsheet.md](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Metasploit%20-%20Cheatsheet.md)  


### PR DESCRIPTION
Linux evasion techniques were previously included as part of persistence, but the number of techniques are varied enough where it likely should be its own article.  (I'm planning to submit an additional PR after this to expand on the existing techniques and to include additional ones.  Adding them all to the persistence page would make it too bulky.)