### PR TITLE
Fix: Broken Link

### DIFF
--- a/Server Side Template Injection/README.md
+++ b/Server Side Template Injection/README.md
@@ -33,7 +33,7 @@
     - [Java - Basic injection](#java---basic-injection)
     - [Java - Retrieve the system’s environment variables](#java---retrieve-the-systems-environment-variables)
     - [Java - Retrieve /etc/passwd](#java---retrieve-etcpasswd)
-  - [Django Template](#django-template)
+  - [Django Templates](#django-templates)
   - [Python - Jinja2](#jinja2)
     - [Jinja2 - Basic injection](#jinja2---basic-injection)
     - [Jinja2 - Template format](#jinja2---template-format)


### PR DESCRIPTION
Changed name in summary links: Django Template > Django Templates
Fixed corresponding link: #django-template > #django-templates