### PR TITLE
feat: Backgrounding long running commands

### DIFF
--- a/Command Injection/README.md
+++ b/Command Injection/README.md
@@ -25,6 +25,7 @@
 * [Time based data exfiltration](#time-based-data-exfiltration)
 * [DNS based data exfiltration](#dns-based-data-exfiltration)
 * [Polyglot command injection](#polyglot-command-injection)
+* [Backgrounding long running commands](#backgrounding-long-running-commands)
 * [References](#references)
     
 

--- a/Command Injection/README.md
+++ b/Command Injection/README.md
@@ -297,6 +297,16 @@ echo "YOURCMD/*$(sleep 5)`sleep 5``*/-sleep(5)-'/*$(sleep 5)`sleep 5` #*/-sleep(
 echo 'YOURCMD/*$(sleep 5)`sleep 5``*/-sleep(5)-'/*$(sleep 5)`sleep 5` #*/-sleep(5)||'"||sleep(5)||"/*`*/'
 ```
 
+## Backgrounding long running commands
+
+In some instances, you might have a long running command that gets killed by the process injecting it timing out.
+
+Using nohup, you can keep the process running after the parent process exits.
+
+```bash
+nohup sleep 120 > /dev/null &
+```
+
 ## Labs
 
 * [OS command injection, simple case](https://portswigger.net/web-security/os-command-injection/lab-simple)


### PR DESCRIPTION
Example of using nohup and & to run a command that won't be killed by, e.g. a PHP timeout.