### PR TITLE
Fix broken link not compatible with MkDocs

### DIFF
--- a/Methodology and Resources/Active Directory Attack.md
+++ b/Methodology and Resources/Active Directory Attack.md
@@ -224,7 +224,7 @@ Use the correct collector
 * AzureHound for Azure Active Directory
 * SharpHound for local Active Directory
 
-* use [AzureHound](https://github.com/BloodHoundAD/AzureHound) (more info: [Cloud - Azure Pentest](Cloud%20-%20Azure%20Pentest.md/#azure-recon-tools))
+* use [AzureHound](https://github.com/BloodHoundAD/AzureHound) (more info: [Cloud - Azure Pentest](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Cloud%20-%20Azure%20Pentest.md#azure-recon-tools))
 
 * use [BloodHound](https://github.com/BloodHoundAD/BloodHound)
   ```powershell


### PR DESCRIPTION
Relative github link `Cloud%20-%20Azure%20Pentest.md/#azure-recon-tools` is converted with MkDocs to:
```
https://swisskyrepo.github.io/PayloadsAllTheThingsWeb/Methodology%20and%20Resources/Active%20Directory%20Attack/Cloud%20-%20Azure%20Pentest.md/#azure-recon-tools
```
Instead of
```
https://swisskyrepo.github.io/PayloadsAllTheThingsWeb/Methodology%20and%20Resources/Cloud%20-%20Azure%20Pentest/#azure-recon-tools
```

A fix on this could be interesting. We could even go further and convert automatically links in .md files such as `https://github.com/swisskyrepo/PayloadsAllTheThings/` to `https://swisskyrepo.github.io/PayloadsAllTheThingsWeb`.