### PR TITLE
Add SQLmap with Proxychains

### DIFF
--- a/SQL Injection/README.md
+++ b/SQL Injection/README.md
@@ -189,6 +189,12 @@ sqlmap -u "http://www.target.com" --tor --tor-type=SOCKS5 --time-sec 11 --check-
 sqlmap -u "http://www.target.com" --proxy="http://127.0.0.1:8080"
 ```
 
+### Using Proxychains with SQLmap
+
+```powershell
+proxychains sqlmap -u "http://www.target.com"
+```
+
 ### Using Chrome cookie and a Proxy
 
 ```powershell


### PR DESCRIPTION
Added command for using SQLmap with proxychains to the README.md file in the SQL injection dir. Was going to add a little bit stating that the editing of the proxychains config file is needed to use proxys but I'm not quite sure how/where I would add that little extra bit.