### PR TITLE
fix: remove docker metasploit installation

### DIFF
--- a/Methodology and Resources/Metasploit - Cheatsheet.md
+++ b/Methodology and Resources/Metasploit - Cheatsheet.md
@@ -28,12 +28,6 @@
 curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb > msfinstall && chmod 755 msfinstall && ./msfinstall
 ```
 
-or docker
-
-```powershell
-sudo docker run --rm -it -p 443:443 -v ~/.msf4:/root/.msf4 -v /tmp/msf:/tmp/data remnux/metasploit
-```
-
 ## Sessions
 
 ```powershell


### PR DESCRIPTION
Hello,

This is my contribution to your repo.

In fact, there are two errors in my opinion:
- You don't need sudo to use docker
- The docker image is no longer available ([see yourself](https://hub.docker.com/search?q=remnux%2Fmetasploit))

Like they say to use their installers, I propose not to use the docker image. <https://github.com/rapid7/metasploit-framework>

I'm not an expert on Metasploit, so feel free to ask questions.