### PR TITLE
Fixed Golang net/http param pollution outcome

### DIFF
--- a/HTTP Parameter Pollution/README.md
+++ b/HTTP Parameter Pollution/README.md
@@ -36,12 +36,12 @@ When ?par1=a&par1=b
 | Python Django                                   |Last occurrence          |b              |
 | Nodejs                                          |All occurrences          |a,b            |
 | Golang net/http - `r.URL.Query().Get("param")`  |First occurrence         |a              |
-| Golang net/http - `r.URL.Query()["param"]`      |All occurrences          |a,b            |
+| Golang net/http - `r.URL.Query()["param"]`      |All occurrences in array |['a','b']      |
 | IBM Lotus Domino                                |First occurrence         |a              |
 | IBM HTTP Server                                 |First occurrence         |a              |
 | Perl CGI/Apache                                 |First occurrence         |a              |
 | mod_wsgi (Python)/Apache                        |First occurrence         |a              |
-| Python/Zope                                     |All occurrences in array  |['a','b']      |
+| Python/Zope                                     |All occurrences in array |['a','b']      |
 | Ruby on Rails                                   |Last occurrence          |b              |
 
 ## References


### PR DESCRIPTION
Fixed Golang net/http param pollution outcome since it returns an array (as the Python/Zope outcome).
Tested with the following:

`test.go`
```golang
package main

import (
	"log"
	"net/http"
)

func main() {
	http.ListenAndServe(":1234", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		log.Println("Indexing:", r.URL.Query()["param"], "Get():", r.URL.Query().Get("param"))
	}))
}
```
```sh
$ go run ./test.go & sleep 1 && curl 'localhost:1234?param=one&param=two'
2023/04/14 14:51:20 Indexing: [one two] Get(): one
```