### PR TITLE
feat: add cognito-scanner tool for AWS pentest

### DIFF
--- a/Methodology and Resources/Cloud - AWS Pentest.md
+++ b/Methodology and Resources/Cloud - AWS Pentest.md
@@ -185,6 +185,17 @@
     find_admins: Look at IAM policies to identify admin users and roles, or principals with specific privileges
     ```
 
+* [Cognito Scanner](https://github.com/padok-team/cognito-scanner) - A CLI tool for executing attacks on cognito such as *Unwanted account creation*, *Account Oracle* and *Identity Pool escalation*.
+    ```bash
+    # Installation
+    $ pip install cognito-scanner
+    # Usage
+    $ cognito-scanner --help
+    # Get information about how to use the unwanted account creation script
+    $ cogntio-scanner account-creation --help
+    # For more details go to https://github.com/padok-team/cognito-scanner
+    ```
+
 * [dufflebag](https://labs.bishopfox.com/dufflebag) - Find secrets that are accidentally exposed via Amazon EBS's "public" mode
 * [NetSPI/AWS Consoler](https://github.com/NetSPI/aws_consoler) - Convert AWS Credentials into a console access
 


### PR DESCRIPTION
Cognito Scanner is a CLI open-source tool. It enables to pentest Cognito AWS instance easily. It can be installed through a python package