### PR TITLE
Update Ruby.md

### DIFF
--- a/Insecure Deserialization/Ruby.md
+++ b/Insecure Deserialization/Ruby.md
@@ -58,6 +58,6 @@ Universal gadget for ruby 2.x - 3.x.
 
 - [RUBY 2.X UNIVERSAL RCE DESERIALIZATION GADGET CHAIN - elttam, Luke Jahnke](https://www.elttam.com.au/blog/ruby-deserialization/)
 - [Universal RCE with Ruby YAML.load - @_staaldraad ](https://staaldraad.github.io/post/2019-03-02-universal-rce-ruby-yaml-load/)
-- [Online access to Ruby 2.x Universal RCE Deserialization Gadget Chain - PentesterLab](https://pentesterlab.com/exercises/ruby_ugadget/online)
+- [Online access to Ruby 2.x Universal RCE Deserialization Gadget Chain - PentesterLab](https://pentesterlab.com/exercises/ruby_ugadget/course)
 - [Universal RCE with Ruby YAML.load (versions > 2.7) - @_staaldraad](https://staaldraad.github.io/post/2021-01-09-universal-rce-ruby-yaml-load-updated/)
 * [Blind Remote Code Execution through YAML Deserialization - 09 JUNE 2021](https://blog.stratumsecurity.com/2021/06/09/blind-remote-code-execution-through-yaml-deserialization/)


### PR DESCRIPTION
Change from the invalid 404 URL to the valid one.

The old one (https://pentesterlab.com/exercises/ruby_ugadget/score) can't be accessed as shown below.
![2024-05-05_16-17](https://github.com/swisskyrepo/PayloadsAllTheThings/assets/12832679/c5487ec9-99ad-42af-8f4a-09bb911291d9)


The new one (https://pentesterlab.com/exercises/ruby_ugadget/course) can be accessed properly as shown in the following figure.
![2024-05-05_16-17_1](https://github.com/swisskyrepo/PayloadsAllTheThings/assets/12832679/8ec64de0-568f-40d6-becf-ac222f02bb78)
