### PR TITLE
Update Reverse Shell Cheatsheet.md

### DIFF
--- a/Methodology and Resources/Reverse Shell Cheatsheet.md
+++ b/Methodology and Resources/Reverse Shell Cheatsheet.md
@@ -1,6 +1,6 @@
 # Reverse Shell Cheat Sheet
 
-:warning: Content of this page has been moved to [InternalAllTheThings/cheatsheet/shell-reverse](https://swisskyrepo.github.io/InternalAllTheThings/cheatsheets/shell-reverse-cheatsheet/)
+:warning: Content of this page has been moved to [InternalAllTheThings/cheatsheet/shell-reverse](https://github.com/swisskyrepo/InternalAllTheThings/blob/main/docs/cheatsheets/shell-reverse-cheatsheet.md)
 
 * [Tools](https://swisskyrepo.github.io/InternalAllTheThings/cheatsheets/shell-reverse-cheatsheet/#tools)
 * [Reverse Shell](https://swisskyrepo.github.io/InternalAllTheThings/cheatsheets/shell-reverse-cheatsheet/#reverse-shell)


### PR DESCRIPTION
The original redirect link to InternalAllTheThings repo was broken. Added the correct redirect link for the reverse shell cheatsheet in InternalAllTheThings  repo.