### PR TITLE
Add missing -r flag for xxe excel file rebuilding with zip command

### DIFF
--- a/XXE Injection/README.md
+++ b/XXE Injection/README.md
@@ -596,7 +596,7 @@ Rebuild Excel file:
 
 ```
 $ cd XXE
-$ zip -u ../xxe.xlsx *
+$ zip -r -u ../xxe.xlsx *
 ```
 
 Warning: Use `zip -u` (https://infozip.sourceforge.net/Zip.html) and not `7z u` / `7za u` (https://p7zip.sourceforge.net/) or `7zz` (https://www.7-zip.org/) because they won't recompress it the same way and many Excel parsing libraries will fail to recognize it as a valid Excel file. A valid  magic byte signature with (`file XXE.xlsx`) will be shown as `Microsoft Excel 2007+` (with `zip -u`) and an invalid one will be shown as `Microsoft OOXML`.


### PR DESCRIPTION
-r flag is needed to include sub directories in the final archive

```bash
$ zip -u
```

```bash
  adding: [Content_Types].xml (deflated 77%)
  adding: docProps/ (stored 0%)
  adding: _rels/ (stored 0%)
  adding: xl/ (stored 0%)
```

```bash
$ zip -r -u
```

```bash
  adding: [Content_Types].xml (deflated 77%)
  adding: docProps/ (stored 0%)
  adding: docProps/custom.xml (deflated 37%)
  adding: docProps/core.xml (deflated 51%)
  adding: docProps/app.xml (deflated 39%)
  adding: _rels/ (stored 0%)
  adding: _rels/.rels (deflated 67%)
  adding: xl/ (stored 0%)
  adding: xl/worksheets/ (stored 0%)
  adding: xl/worksheets/sheet1.xml (deflated 71%)
  adding: xl/workbook.xml (deflated 43%)
  adding: xl/sharedStrings.xml (deflated 87%)
  adding: xl/theme/ (stored 0%)
  adding: xl/theme/theme1.xml (deflated 76%)
  adding: xl/_rels/ (stored 0%)
  adding: xl/_rels/workbook.xml.rels (deflated 67%)
  adding: xl/styles.xml (deflated 90%)
```