### PR TITLE
feat: Add resources for Model Context Protocol (MCP) Pentesting

### DIFF
--- a/Methodology and Resources/Model Context protocol Pentesting Techniques.md
+++ b/Methodology and Resources/Model Context protocol Pentesting Techniques.md
@@ -1,0 +1,137 @@
+# Model Context Protocol
+
+Model Context Protocol (MCP) is a specification for a programmatic tool interface where the caller is a language model (LLM). It is designed to allow LLMs to interact with external tools and resources.
+
+## Known Vulnerabilities
+
+### Tool Poisoning (or "Line Jumping")
+
+Tool poisoning is a malicious MCP behavior that leverages prompt injection techniques to influence client behavior without the user’s knowledge. This attack occurs before the invocation of a tool as part of the `tools/list` response from the initial MCP handshake.
+
+### Tool Shadowing
+
+Tool shadowing can refer to cross-server poisoning of legitimate behavior via side effects or to name-collision attacks. Current MCP clients may allow multiple servers to provide tools with the same name, leading to unpredictable behavior.
+
+### "Rug-pulling"
+
+The MCP specification does not currently have any sort of requirement to broadcast when tools are changed. This can lead to a "rug-pulling" attack where a benign remote server is replaced with a malicious one.
+
+### Web 2.0 Issues
+
+Because MCP servers support JSON-RPC over HTTP, they are vulnerable to common web application vulnerabilities, such as:
+
+*   Request smuggling/HTTP response splitting
+*   Path traversal
+*   Injection issues (SQL, shell, LDAP, etc.)
+*   Permissive JSON parsing without validating `Content-Type` header
+
+### Sampling Vulnerabilities
+
+The MCP specification has no requirements for isolation when sampling. This can be exploited by a malicious MCP server to request tool names from other servers and then dynamically register name collisions.
+
+## Penetration Testing MCP
+
+### MCP Inspector
+
+The MCP Inspector is a tool for auditing MCP servers. It allows you to inspect the protocol handshake and get a deterministic list of the tools, resources, and prompts provided by the server.
+
+### Local Server Testing (stdio)
+
+The simplest way to get MCP up and running is local-only, communicating over stdio. These setups should be audited for potential command injection faults.
+
+### MCP Security Checklist
+
+The following checklist is from the Semgrep blog post "A Security Engineer's Guide to MCP".
+
+#### MCP Server Cheatsheet
+
+**Transports**
+
+*   What transports are supported?
+*   If HTTP transport is supported, are the network bindings acceptable?
+*   If HTTP transport is supported, is the server doing origin validation?
+
+**Authorization/Authentication**
+
+*   Is the server authorized?
+*   If authorization is enabled:
+    *   Is the server properly implementing OAuth 2.1?
+    *   Is the server performing audience validation?
+    *   Is the server using sessions for authentication purposes? (Should be no)
+*   Is the server doing pass-through authorization? (Should be no)
+*   Does the server support dynamic client registration?
+
+**MCP Features**
+
+*   Does the server support elicitation?
+*   Does the server support sampling?
+*   Does the server correctly query the client for roots when performing path operations?
+*   Does the server properly prompt for consent before performing sampling or third party data transmission?
+*   Are session IDs generated from a cryptographically secure pseudorandom number generator (CSPRNG)?
+*   Are sessions reused?
+
+**Isolation and Sanitization**
+
+*   Does the server service multiple clients?
+*   How is client data isolated from other requests?
+*   Does the server perform path operations with client data?
+*   Does the server perform shell operations with client data?
+*   Does the server perform HTTP requests with client data?
+*   Does the server perform FTP requests with client data?
+*   Does the server perform LDAP requests with client data?
+
+#### MCP Client Cheatsheet
+
+**Roots**
+
+*   Does the client support roots?
+*   Does the client expose roots with appropriate permissions?
+*   Does the client validate root URIs?
+*   Does the client verify the accessibility of the root to the client?
+
+**Sampling**
+
+*   Does the client support sampling?
+*   Does sampling always prompt a human for approval?
+*   Does the client allow the user to preview the sampling response before sending it to the requestor?
+*   Does the client have any special handling of potentially sensitive data?
+
+**Elicitation**
+
+*   Does the client support elicitation?
+*   Does the client clearly display the server requesting an elicitation response?
+*   Does the client allow the user to review and modify their response before submission?
+
+**Isolation and Sanitization**
+
+*   Does the client treat tool descriptions as untrusted?
+*   Does the client treat tool output as untrusted?
+*   How does the client handle name collisions?
+*   Does the client always prompt for human approval on first-run?
+
+## Security Advisories
+
+### Grafana MCP Server Exposes Unauthenticated SSE Interface
+
+*   **Vulnerability:** The Grafana MCP Server, when launched with the `-t sse` flag, exposes an unauthenticated Server-Sent Events (SSE) interface on `0.0.0.0:8000` by default.
+*   **Impact:** Remote attackers with network access can interact with the victim's Grafana instance without authentication, allowing them to manipulate dashboards (list, create, update, delete), access data sources, and other privileged Grafana functionality.
+*   **Mitigation:** Avoid using `-t sse` on untrusted networks, use `localhost` binding, and implement network-level restrictions.
+
+### Coder's Agent API Exposes User Chat History Via DNS Rebinding Attack
+
+*   **Vulnerability:** A DNS rebinding vulnerability in Coder's Agent API allowed remote attackers to exfiltrate a user's Claude Code message history.
+*   **Impact:** The chat history could include sensitive data like secret keys, file system contents, and intellectual property.
+*   **Mitigation:** Update to Coder Agent API release v0.4.0 or later. Developers are advised to implement robust Host header validation, CSRF protection, and security warnings.
+
+### thirdweb MCP Server Enables Unauthorized Crypto Transactions
+
+*   **Vulnerability:** The thirdweb MCP Server, when launched with the `--transport sse` flag, exposes an unauthenticated Server-Sent Events (SSE) interface on `0.0.0.0:8000` by default.
+*   **Impact:** Remote attackers can execute unauthorized cryptocurrency transactions from victims' wallets without authentication.
+*   **Mitigation:** Avoid using `--transport sse` in shared networks, use `localhost` binding, and implement network-level restrictions. Developers should change the default binding to `127.0.0.1` and implement authentication.
+
+## References
+
+*   [A Security Engineer's Guide to MCP](https://semgrep.dev/blog/2025/a-security-engineers-guide-to-mcp/)
+*   [Grafana MCP Server Exposes Unauthenticated SSE Interface](https://mcpsec.dev/advisories/2025-09-02-grafana-mcp-unauthenticated-sse-access/)
+*   [Coder's Agent API Exposes User Chat History Via DNS Rebinding Attack](https://mcpsec.dev/advisories/2025-09-19-coder-chat-exfiltration/)
+*   [thirdweb MCP Server Enables Unauthorized Crypto Transactions](https://mcpsec.dev/advisories/2025-09-03-thirdweb-mcp-unauthorized-transactions/)


### PR DESCRIPTION
This PR adds a new section for the Model Context Protocol (MCP), including a README.md file with a summary of the protocol, known vulnerabilities, and a penetration testing checklist.