### PR TITLE
Update Web Attack Surface.md

### DIFF
--- a/Methodology and Resources/Web Attack Surface.md
+++ b/Methodology and Resources/Web Attack Surface.md
@@ -1,6 +1,6 @@
 # Subdomains Enumeration
 
-:warning: Content of this page has been moved to [InternalAllTheThings/redteam/access/web-attack-surface](https://github.com/swisskyrepo/InternalAllTheThings/redteam/access/web-attack-surface)
+:warning: Content of this page has been moved to [InternalAllTheThings/redteam/access/web-attack-surface](https://github.com/swisskyrepo/InternalAllTheThings/blob/main/docs/redteam/access/web-attack-surface.md)
 
 - [Enumerate Subdomains](https://swisskyrepo.github.io/InternalAllTheThings/redteam/access/web-attack-surface/#enumerate-subdomains)
     - [Subdomains Databases](https://swisskyrepo.github.io/InternalAllTheThings/redteam/access/web-attack-surface/#subdomains-databases)


### PR DESCRIPTION
Hi,

**Fixed:**
- Missing path - added `/blob/main/docs/`

As there is no `issues` tab, a short description about the problem.

**Repro steps:**
1. Visit https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Web%20Attack%20Surface.md
2. Notice "⚠️ Content of this page has been moved to InternalAllTheThings/redteam/access/web-attack-surface" with invalid link `https://github.com/swisskyrepo/InternalAllTheThings/redteam/access/web-attack-surface`

**Screenshot**
Current view - `error 404` page:
<img width="575" height="500" alt="bug" src="https://github.com/user-attachments/assets/76d5c611-0650-4a25-9fbe-ca063d4be293" />

It is changed / updated to valid link:
https://github.com/swisskyrepo/InternalAllTheThings/blob/main/docs/redteam/access/web-attack-surface.md

View after fix:
<img width="972" height="846" alt="fixed" src="https://github.com/user-attachments/assets/b1cf7b12-1abb-4621-9c79-9fe0f916967d" />


I was little confused for a while. This PR should implement the fix.

Best wishes,