### PR TITLE
add code review section with Java examples

### DIFF
--- a/XXE Injection/README.md
+++ b/XXE Injection/README.md
@@ -35,6 +35,8 @@
     - [XXE Inside DOCX file](#xxe-inside-docx-file)
     - [XXE Inside XLSX file](#xxe-inside-xlsx-file)
     - [XXE Inside DTD file](#xxe-inside-dtd-file)
+- [Code review](#code-review)
+  - [XML parsers in Java](#xml-parsers-in-java)
 - [Labs](#labs)
 - [References](#references)
 
@@ -634,6 +636,29 @@ When all you control is the DTD file, and you do not control the `xml` file, XXE
 %param1;
 %external;
 ```
+
+## Code review
+  
+### XML parsers in Java
+
+Unsecure configuration in 10 different Java classes from three XML processing interfaces (DOM, SAX, StAX) that can lead to XXE:
+
+![XXE Java security features overview infographics](https://semgrep.dev/docs/assets/images/cheat-sheets-xxe-java-infographics-1d1d5016802e3ab8f0886b62b8c81f21.png)
+
+- [DocumentBuilderFactory (javax.xml.parsers.DocumentBuilderFactory)](https://semgrep.dev/docs/cheat-sheets/java-xxe/#3a-documentbuilderfactory)
+- [SAXBuilder (org.jdom2.input.SAXBuilder)](https://semgrep.dev/docs/cheat-sheets/java-xxe/#3b-saxbuilder)
+- [SAXParserFactory (javax.xml.parsers.SAXParserFactory)](https://semgrep.dev/docs/cheat-sheets/java-xxe/#3c-saxparserfactory)
+- [SAXParser (javax.xml.parsers.SAXParser )](https://semgrep.dev/docs/cheat-sheets/java-xxe/#3d-saxparser)
+- [SAXReader (org.dom4j.io.SAXReader)](https://semgrep.dev/docs/cheat-sheets/java-xxe/#3e-saxreader)
+- [TransformerFactory (javax.xml.transform.TransformerFactory) & SAXTransformerFactory (javax.xml.transform.sax.SAXTransformerFactory)](https://semgrep.dev/docs/cheat-sheets/java-xxe/#3f-transformerfactory--saxtransformerfactory)
+- [SchemaFactory (javax.xml.validation.SchemaFactory)](https://semgrep.dev/docs/cheat-sheets/java-xxe/#3g-schemafactory)
+- [Validator (javax.xml.validation.Validator)](https://semgrep.dev/docs/cheat-sheets/java-xxe/#3h-validator)
+- [XMLReader (org.xml.sax.XMLReader)](https://semgrep.dev/docs/cheat-sheets/java-xxe/#3i-xmlreader)
+
+Ref.
+
+- [Semgrep - XML Security in Java](https://semgrep.dev/blog/2022/xml-security-in-java)
+- [Semgrep - XML External entity prevention for Java](https://semgrep.dev/docs/cheat-sheets/java-xxe/)
 
 ## Labs
 


### PR DESCRIPTION
I wanted to re-introduce #616, that was removed by mistake in 98cfc9ce8c06c9f48d7d91e8f17167c3b4bb5ff7 (commit that was supposed to remove XXE Error Based Local DTD content).