### PR TITLE
docs: normalize dependency confusion reference dates

### DIFF
--- a/Dependency Confusion/README.md
+++ b/Dependency Confusion/README.md
@@ -33,7 +33,7 @@ Look for `npm`, `pip`, `gem` packages, the methodology is the same : you registe
 
 ## References
 
-* [Exploiting Dependency Confusion - Aman Sapra (0xsapra) - 2 Jul 2021](https://web.archive.org/web/20251107024922/https://0xsapra.github.io/website/Exploiting-Dependency-Confusion)
-* [Dependency Confusion: How I Hacked Into Apple, Microsoft and Dozens of Other Companies - Alex Birsan - 9 Feb 2021](https://web.archive.org/web/20210209181139/https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)
-* [3 Ways to Mitigate Risk When Using Private Package Feeds - Microsoft - 29/03/2021](https://web.archive.org/web/20210210121930/https://azure.microsoft.com/en-gb/resources/3-ways-to-mitigate-risk-using-private-package-feeds/)
-* [$130,000+ Learn New Hacking Technique in 2021 - Dependency Confusion - Bug Bounty Reports Explained - 22 févr. 2021](https://web.archive.org/web/20210223060107/https://www.youtube.com/watch?v=zFHJwehpBrU)
+* [Exploiting Dependency Confusion - Aman Sapra (0xsapra) - July 2, 2021](https://web.archive.org/web/20251107024922/https://0xsapra.github.io/website/Exploiting-Dependency-Confusion)
+* [Dependency Confusion: How I Hacked Into Apple, Microsoft and Dozens of Other Companies - Alex Birsan - February 9, 2021](https://web.archive.org/web/20210209181139/https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)
+* [3 Ways to Mitigate Risk When Using Private Package Feeds - Microsoft - March 29, 2021](https://web.archive.org/web/20210210121930/https://azure.microsoft.com/en-gb/resources/3-ways-to-mitigate-risk-using-private-package-feeds/)
+* [$130,000+ Learn New Hacking Technique in 2021 - Dependency Confusion - Bug Bounty Reports Explained - February 22, 2021](https://web.archive.org/web/20210223060107/https://www.youtube.com/watch?v=zFHJwehpBrU)


### PR DESCRIPTION
## Summary

- Normalize Dependency Confusion reference dates to the `Month Number, Year` format required by CONTRIBUTING.md.
- Keep the change scoped to `Dependency Confusion/README.md` only.

## Validation

- `git diff --check`
- `npx --yes markdownlint-cli2@0.15.0 "Dependency Confusion/README.md" --config .github/.markdownlint.json`
