### PR TITLE
Add mcp-safeguard — prompt injection scanner for MCP servers

### DIFF
--- a/Prompt Injection/README.md
+++ b/Prompt Injection/README.md
@@ -38,6 +38,7 @@ Tools to identify and attack Large Language Models.
 * [praetorian-inc/julius](https://github.com/praetorian-inc/julius) - Simple LLM service identification - translate IP:Port to Ollama, vLLM, LiteLLM, or 15+ other AI services in seconds
 * [praetorian-inc/augustus](https://github.com/praetorian-inc/augustus) - LLM security testing framework for detecting prompt injection, jailbreaks, and adversarial attacks — 190+ probes, 28 providers, single Go binary
 * [promptfoo/promptfoo](https://github.com/promptfoo/promptfoo) - Test your prompts, agents, and RAGs. AI Red teaming, pentesting, and vulnerability scanning for LLMs.
+* [mcp-safeguard](https://github.com/SyedAnas01/mcp-safeguard) - Security scanner detecting prompt injection in MCP tool descriptions, credential leaks, exposed endpoints, and tool poisoning in AI agent infrastructure.
 
 Challenges
 


### PR DESCRIPTION
mcp-safeguard detects prompt injection attacks embedded in MCP (Model Context Protocol) tool descriptions — a novel attack vector where LLM instructions are hidden in server metadata. Also detects credential leaks, exposed endpoints, and tool poisoning. Relevant to offensive security practitioners targeting AI agent infrastructure. https://github.com/SyedAnas01/mcp-safeguard