### PR TITLE
Add glotfiles to Upload Insecure Files tools

### DIFF
--- a/Upload Insecure Files/README.md
+++ b/Upload Insecure Files/README.md
@@ -21,6 +21,7 @@
 
 * [almandin/fuxploiderFuxploider](https://github.com/almandin/fuxploider) - File upload vulnerability scanner and exploitation tool.
 * [Burp/Upload Scanner](https://portswigger.net/bappstore/b2244cbb6953442cb3c82fa0a0d908fa) -  HTTP file upload scanner for Burp Proxy.
+* [glotfiles](https://www.glotfiles.dev/) - Browser-based generator for polyglot files (PDF+ZIP, image+ZIP, PDF+image and others), useful for testing file type validation.
 * [ZAP/FileUpload](https://www.zaproxy.org/blog/2021-08-20-zap-fileupload-addon/) -  OWASP ZAP add-on for finding vulnerabilities in File Upload functionality.
 
 ## Methodology


### PR DESCRIPTION
Adds one entry to the Tools list on the Upload Insecure Files page.

glotfiles is a browser-based generator for polyglot files — single files that are simultaneously valid under two or more format specifications (PDF+ZIP, image+ZIP, PDF+image, and several three- and four-format combinations).

Relevance to this page: the Upload Tricks section already covers swapping magic bytes by hand to get past file type validation. This generates those files directly, which is useful when testing whether an upload filter validates by extension, MIME type, or actual content.

Consistent with the existing entries, it is a hosted tool rather than a repository — same as the Burp and ZAP entries already in that list. Placed alphabetically between them.

Disclosure: I built this tool. No account or installation is required to use it.
